### PR TITLE
Rename action for marketplace

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,5 +1,5 @@
-name: "backport-action"
-description: "Automatically backport pull requests"
+name: "Backport"
+description: "Cherry-pick commits from labelled pull requests (supports Merge Queue & Bors)"
 author: "korthout"
 inputs:
   github_token:


### PR DESCRIPTION
The name `backport-action` was already in use. Let's see if `Backport` would be allowed.

We need to merge this to `main` for it to be considered in the publishing (even a tag is not enough).