### PR TITLE
Try to organize all branches in particular folder

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,13 +6,6 @@ on:
         description: The new version to release, e.g. 1.0.0
         type: string
         required: true
-      type:
-        type: choice
-        description: Is this a major, minor or patch release?
-        options:
-        - major
-        - minor
-        - patch
       nextDevelopmentVersion:
         description: >
           The new version to use during development, e.g. 1.1.0-SNAPSHOT
@@ -21,7 +14,7 @@ on:
       dryRun:
         description: Don't push commits or tags
         type: boolean
-        default: false
+        default: true
 concurrency: release
 jobs:
   release:
@@ -59,35 +52,19 @@ jobs:
           include: "package.json"
           regex: false
 
-      - name: Extract major, minor and patch version components
+      - name: Extract semver release version components
         uses: madhead/semver-utils@v3
         id: version
         with:
-          version: ${{ input.releaseVersion }}
+          version: ${{ inputs.releaseVersion }}
 
-      - name: Move and create tags for patch release
-        if: ${{ input.type == 'patch' }}
+      - name: Create and move major/minor tags
         run:
-          git tag --delete v${{ steps.version.outputs.major }}
-          git tag --delete v${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}
-          git tag v${{ steps.version.outputs.major }}
-          git tag v${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}
-
-      - name: Move and create tags for minor release
-        if: ${{ input.type == 'minor' }}
-        run:
-          git tag --delete v${{ steps.version.outputs.major }}
-          git tag v${{ steps.version.outputs.major }}
-          git tag v${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}
-
-      - name: Create tags for major release
-        if: ${{ input.type == 'major' }}
-        run:
-          git tag v${{ steps.version.outputs.major }}
-          git tag v${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}
+          git tag v${{ steps.version.outputs.major }} --force
+          git tag v${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }} --force
 
       - name: Push major/minor tags
-        if: ${{ intput.dryRun == false }}
+        if: ${{ inputs.dryRun == false }}
         run:
           git push origin v${{ steps.version.outputs.major }} --force
           git push origin v${{ steps.version.outputs.minor }} --force

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,13 @@ on:
         description: The new version to release, e.g. 1.0.0
         type: string
         required: true
+      type:
+        type: choice
+        description: Is this a major, minor or patch release?
+        options:
+        - major
+        - minor
+        - patch
       nextDevelopmentVersion:
         description: >
           The new version to use during development, e.g. 1.1.0-SNAPSHOT
@@ -51,6 +58,39 @@ jobs:
           replace: '"version": "${{ inputs.nextDevelopmentVersion }}"'
           include: "package.json"
           regex: false
+
+      - name: Extract major, minor and patch version components
+        uses: madhead/semver-utils@v3
+        id: version
+        with:
+          version: ${{ input.releaseVersion }}
+
+      - name: Move and create tags for patch release
+        if: ${{ input.type == 'patch' }}
+        run:
+          git tag --delete v${{ steps.version.outputs.major }}
+          git tag --delete v${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}
+          git tag v${{ steps.version.outputs.major }}
+          git tag v${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}
+
+      - name: Move and create tags for minor release
+        if: ${{ input.type == 'minor' }}
+        run:
+          git tag --delete v${{ steps.version.outputs.major }}
+          git tag v${{ steps.version.outputs.major }}
+          git tag v${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}
+
+      - name: Create tags for major release
+        if: ${{ input.type == 'major' }}
+        run:
+          git tag v${{ steps.version.outputs.major }}
+          git tag v${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }}
+
+      - name: Push major/minor tags
+        if: ${{ intput.dryRun == false }}
+        run:
+          git push origin v${{ steps.version.outputs.major }} --force
+          git push origin v${{ steps.version.outputs.minor }} --force
 
       - name: Commit next development version
         id: commit-next-dev

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,66 @@
+name: Release
+on:
+  workflow_dispatch:
+    inputs:
+      releaseVersion:
+        description: The new version to release, e.g. 1.0.0
+        type: string
+        required: true
+      nextDevelopmentVersion:
+        description: >
+          The new version to use during development, e.g. 1.1.0-SNAPSHOT
+        type: string
+        required: true
+      dryRun:
+        description: Don't push commits or tags
+        type: boolean
+        default: false
+concurrency: release
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      
+      - name: Set release version in package.json
+        uses: jacobtomlinson/gha-find-replace@v3
+        with:
+          find: '"version": "[0-9\.]+(-SNAPSHOT)?"'
+          replace: '"version": "${{ inputs.releaseVersion }}"'
+          include: package.json
+          regex: true
+      
+      - name: Commit new release version
+        id: commit-new-release
+        uses: EndBug/add-and-commit@v9
+        with:
+          commit: --signoff
+          default_author: github_actions
+          fetch: false
+          message: 'dist: release ${{ inputs.releaseVersion }}'
+          push: ${{ inputs.dryRun == false }}
+          tag: v${{ inputs.releaseVersion }}
+      
+      - name: Print new release version commit
+        run: git show ${{ steps.commit-new-release.outputs.commit_sha }} | cat
+      
+      - name: Set development version in package.json
+        uses: jacobtomlinson/gha-find-replace@v3
+        with:
+          find: '"version": "${{ inputs.releaseVersion }}"'
+          replace: '"version": "${{ inputs.nextDevelopmentVersion }}"'
+          include: "package.json"
+          regex: false
+
+      - name: Commit next development version
+        id: commit-next-dev
+        uses: EndBug/add-and-commit@v9
+        with:
+          commit: --signoff
+          default_author: github_actions
+          fetch: false
+          message: 'dist: release ${{ inputs.nextDevelopmentVersion }}'
+          push: ${{ inputs.dryRun == false }}
+      
+      - name: Print next development version commit
+        run: git show ${{ steps.commit-next-dev.outputs.commit_sha }} | cat

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -146,8 +146,10 @@ export class Backport {
           }
         }
 
+        const folderName = `backport`;
+
         try {
-          const branchname = `backport-${pull_number}-to-${target}`;
+          const branchname = `${folderName}/backport-${pull_number}-to-${target}`;
 
           console.log(`Start backport to ${branchname}`);
           try {


### PR DESCRIPTION
It might be better to organize all backport branches in a particular folder. By this way, we can prevent messing up (as a view) the view of original branch structure.