### PR TITLE
Add automatic release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,83 @@
+name: Release
+on:
+  workflow_dispatch:
+    inputs:
+      releaseVersion:
+        description: The new version to release, e.g. 1.0.0
+        type: string
+        required: true
+      nextDevelopmentVersion:
+        description: >
+          The new version to use during development, e.g. 1.1.0-SNAPSHOT
+        type: string
+        required: true
+      dryRun:
+        description: Don't push commits or tags
+        type: boolean
+        default: true
+concurrency: release
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Set release version in package.json
+        uses: jacobtomlinson/gha-find-replace@v3
+        with:
+          find: '"version": "[0-9\.]+(-SNAPSHOT)?"'
+          replace: '"version": "${{ inputs.releaseVersion }}"'
+          include: package.json
+          regex: true
+
+      - name: Commit new release version
+        id: commit-new-release
+        uses: EndBug/add-and-commit@v9
+        with:
+          commit: --signoff
+          default_author: github_actions
+          fetch: false
+          message: 'dist: release ${{ inputs.releaseVersion }}'
+          push: ${{ inputs.dryRun == false }}
+          tag: v${{ inputs.releaseVersion }}
+
+      - name: Print new release version commit
+        run: git show ${{ steps.commit-new-release.outputs.commit_sha }} | cat
+
+      - name: Set development version in package.json
+        uses: jacobtomlinson/gha-find-replace@v3
+        with:
+          find: '"version": "${{ inputs.releaseVersion }}"'
+          replace: '"version": "${{ inputs.nextDevelopmentVersion }}"'
+          include: "package.json"
+          regex: false
+
+      - name: Extract semver release version components
+        uses: madhead/semver-utils@v3
+        id: version
+        with:
+          version: ${{ inputs.releaseVersion }}
+
+      - name: Create and move major/minor tags
+        run: |
+          git tag v${{ steps.version.outputs.major }} --force
+          git tag v${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }} --force
+
+      - name: Push major/minor tags
+        if: ${{ inputs.dryRun == false }}
+        run: |
+          git push origin v${{ steps.version.outputs.major }} --force
+          git push origin v${{ steps.version.outputs.minor }} --force
+
+      - name: Commit next development version
+        id: commit-next-dev
+        uses: EndBug/add-and-commit@v9
+        with:
+          commit: --signoff
+          default_author: github_actions
+          fetch: false
+          message: 'dist: release ${{ inputs.nextDevelopmentVersion }}'
+          push: ${{ inputs.dryRun == false }}
+
+      - name: Print next development version commit
+        run: git show ${{ steps.commit-next-dev.outputs.commit_sha }} | cat


### PR DESCRIPTION
This workflow can be used to release new versions of the backport-action automatically.

- It sets the version in the package.json, and tags this commit.
- It also creates (or moves) tags for the major and minor version.
- It can also dry-run, meaning it does not push any commits or tags. The created commits are always logged.

resolves #313 