### PR TITLE
Add release next preview workflow

### DIFF
--- a/.github/workflows/release-next-preview.yml
+++ b/.github/workflows/release-next-preview.yml
@@ -1,0 +1,14 @@
+name: Release next preview
+on:
+  push:
+    branches:
+      - main
+jobs:
+  move-tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Create and move next-preview tag
+        run: |
+          git tag v1.next-preview --force
+          git push origin v1.next-preview

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,14 @@ jobs:
           git push origin v${{ steps.version.outputs.major }} --force
           git push origin v${{ steps.version.outputs.minor }} --force
 
+      - name: Update release-next-preview workflow
+        uses: jacobtomlinson/gha-find-replace@v3
+        with:
+          find: 'v(\d+)\.next-preview'
+          replace: 'v${{ steps.version.outputs.major }}.next-preview'
+          include: ".github/workflows/release-next-preview.yml"
+          regex: true
+
       - name: Commit next development version
         id: commit-next-dev
         uses: EndBug/add-and-commit@v9


### PR DESCRIPTION
This workflow runs on every commit to main and moves the next preview along. In the future, we could also run it on the branches of previously released major versions.

The workflow is automatically updated on new releases so we don't forgot to update the major part of the version (v1.next-preview, v2.next-preview).