### PR TITLE
Publish artifacts in workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,11 @@
 name: CI
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - main
+      - release*
+  pull_request_target: { }
 
 jobs:
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.BACKPORT_ACTION_PAT }}
       - name: Use Node.js 16.x
         uses: actions/setup-node@v3
         with:
@@ -36,7 +38,7 @@ jobs:
         uses: EndBug/add-and-commit@v9
         with:
           commit: --signoff
-          default_author: github_actions
+          default_author: user_info
           fetch: false
           message: 'dist: build new artifacts'
           push: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,5 +22,16 @@ jobs:
         run: npm run test-verbose
         env:
           CI: true
-      - name: Check source has been packaged
-        run: npm run package && git diff --quiet
+      - name: Package artifacts
+        run: npm run package
+      - name: Publish artifacts
+        if: >
+          github.ref == 'refs/heads/main'
+            || contains('refs/heads/release', github.ref)
+        uses: EndBug/add-and-commit@v9
+        with:
+          commit: --signoff
+          default_author: github_actions
+          fetch: false
+          message: 'dist: build new artifacts'
+          push: true

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,12 +18,12 @@ jobs:
         run: npm run format-check
       - name: Build
         run: npm run build --if-present
+      - name: Package artifacts
+        run: npm run package
       - name: Run Tests
         run: npm run test-verbose
         env:
           CI: true
-      - name: Package artifacts
-        run: npm run package
       - name: Publish artifacts
         if: >
           github.ref == 'refs/heads/main'


### PR DESCRIPTION
This changes the `CI` workflow to package and publish the artifacts automatically.

By packaging and publishing the artifacts in a workflow, we avoid that they have to be part of a pull request. This allows us to eat our own dogfood and backport pull requests automatically. Previously, pull requests could not be backported because the commit with the artifacts would almost certainly lead to conflicts during cherry-picking.

This pull request also limits when the CI workflow is run. It used to be run both on any `push`, and on any `pull_request` event, which is excessive. The workflow actually only needs to be run on pull requests and on any push to `main` or release branch (`release*`). Additionally, contributors should not be able to change the CI that is run on their changes, so it should be run on `pull_request_target` instead of `pull_request`.

closes #312 