### PR TITLE
Exclude headref from selected branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ Must contain a capture group for the target branch.
 Label matching can be disabled entirely using an empty string `''` as pattern.
 
 The action will backport the pull request to each matched target branch.
+Note that the pull request's headref is excluded automatically.
 See [How it works](#how-it-works).
 
 ### `pull_description`
@@ -168,6 +169,7 @@ Please refer to this action's README for all available [placeholders](#placehold
 Default: `''` (disabled)
 
 The action will backport the pull request to each specified target branch (space-delimited).
+Note that the pull request's headref is excluded automatically.
 See [How it works](#how-it-works).
 
 Can be used in addition to backport labels.

--- a/action.yml
+++ b/action.yml
@@ -22,6 +22,7 @@ inputs:
       Regex pattern to match the backport labels on the merged pull request.
       Must contain a capture group for the target branch.
       The action will backport the pull request to each matched target branch.
+      Note that the pull request's headref is excluded automatically.
     default: ^backport ([^ ]+)$
   pull_description:
     description: >
@@ -43,6 +44,7 @@ inputs:
   target_branches:
     description: >
       The action will backport the pull request to each specified target branch (space-delimited).
+      Note that the pull request's headref is excluded automatically.
       Can be used in addition to backport labels.
       By default, only backport labels are used to specify the target branches.
 outputs:

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -378,9 +378,13 @@ export function findTargetBranches(
     `Found target branches in \`target_branches\` input: ${configuredTargetBranches}`
   );
 
-  return [
+  const targetBranches = [
     ...new Set([...targetBranchesFromLabels, ...configuredTargetBranches]),
   ];
+
+  console.log(`Determined target branches: ${targetBranches}`);
+
+  return targetBranches;
 }
 
 function findTargetBranchesFromLabels(

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -378,10 +378,13 @@ export function findTargetBranches(
   console.log(
     `Found target branches in \`target_branches\` input: ${configuredTargetBranches}`
   );
+  console.log(
+    `Exclude pull request's headref from target branches: ${headref}`
+  );
 
   const targetBranches = [
     ...new Set([...targetBranchesFromLabels, ...configuredTargetBranches]),
-  ];
+  ].filter((t) => t !== headref);
 
   console.log(`Determined target branches: ${targetBranches}`);
 

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -264,7 +264,7 @@ export class Backport {
 
   private findTargetBranches(mainpr: PullRequest, config: Config): string[] {
     const labels = mainpr.labels.map((label) => label.name);
-    return findTargetBranches(config, labels);
+    return findTargetBranches(config, labels, mainpr.head.ref);
   }
 
   private composePRContent(target: string, main: PullRequest): PRContent {
@@ -360,7 +360,8 @@ export class Backport {
 
 export function findTargetBranches(
   config: Pick<Config, "labels" | "target_branches">,
-  labels: string[]
+  labels: string[],
+  headref: string
 ) {
   console.log("Determining target branches...");
 

--- a/src/github.ts
+++ b/src/github.ts
@@ -134,6 +134,7 @@ export type PullRequest = {
   body: string | null;
   head: {
     sha: string;
+    ref: string;
   };
   base: {
     sha: string;

--- a/src/test/backport.test.ts
+++ b/src/test/backport.test.ts
@@ -10,33 +10,41 @@ describe("find target branches", () => {
   describe("returns an empty list", () => {
     it("when labels is an empty list", () => {
       expect(
-        findTargetBranches({ labels: { pattern: default_pattern } }, [])
+        findTargetBranches(
+          { labels: { pattern: default_pattern } },
+          [],
+          "feature/one"
+        )
       ).toEqual([]);
     });
 
     it("when none of the labels match the pattern", () => {
       expect(
-        findTargetBranches({ labels: { pattern: default_pattern } }, [
-          "a label",
-          "another-label",
-          "a/third/label",
-        ])
+        findTargetBranches(
+          { labels: { pattern: default_pattern } },
+          ["a label", "another-label", "a/third/label"],
+          "feature/one"
+        )
       ).toEqual([]);
     });
 
     it("when a label matches the pattern but doesn't capture a target branch", () => {
       expect(
-        findTargetBranches({ labels: { pattern: /^no capture group$/ } }, [
-          "no capture group",
-        ])
+        findTargetBranches(
+          { labels: { pattern: /^no capture group$/ } },
+          ["no capture group"],
+          "feature/one"
+        )
       ).toEqual([]);
     });
 
     it("when the label pattern is an empty string", () => {
       expect(
-        findTargetBranches({ labels: { pattern: undefined } }, [
-          "an empty string",
-        ])
+        findTargetBranches(
+          { labels: { pattern: undefined } },
+          ["an empty string"],
+          "feature/one"
+        )
       ).toEqual([]);
     });
 
@@ -44,7 +52,8 @@ describe("find target branches", () => {
       expect(
         findTargetBranches(
           { labels: { pattern: default_pattern }, target_branches: "" },
-          ["a label"]
+          ["a label"],
+          "feature/one"
         )
       ).toEqual([]);
     });
@@ -53,18 +62,21 @@ describe("find target branches", () => {
   describe("returns selected branches", () => {
     it("when a label matches the pattern and captures a target branch", () => {
       expect(
-        findTargetBranches({ labels: { pattern: default_pattern } }, [
-          "backport release-1",
-        ])
+        findTargetBranches(
+          { labels: { pattern: default_pattern } },
+          ["backport release-1"],
+          "feature/one"
+        )
       ).toEqual(["release-1"]);
     });
 
     it("when several labels match the pattern and capture a target branch", () => {
       expect(
-        findTargetBranches({ labels: { pattern: default_pattern } }, [
-          "backport release-1",
-          "backport another/target/branch",
-        ])
+        findTargetBranches(
+          { labels: { pattern: default_pattern } },
+          ["backport release-1", "backport another/target/branch"],
+          "feature/one"
+        )
       ).toEqual(["release-1", "another/target/branch"]);
     });
 
@@ -75,7 +87,8 @@ describe("find target branches", () => {
             labels: { pattern: default_pattern },
             target_branches: "release-1",
           },
-          []
+          [],
+          "feature/one"
         )
       ).toEqual(["release-1"]);
     });
@@ -87,7 +100,8 @@ describe("find target branches", () => {
             labels: { pattern: default_pattern },
             target_branches: "release-1 another/target/branch",
           },
-          []
+          [],
+          "feature/one"
         )
       ).toEqual(["release-1", "another/target/branch"]);
     });
@@ -99,7 +113,8 @@ describe("find target branches", () => {
             labels: { pattern: default_pattern },
             target_branches: "release-1",
           },
-          ["backport release-1"]
+          ["backport release-1"],
+          "feature/one"
         )
       ).toEqual(["release-1"]);
     });

--- a/src/test/backport.test.ts
+++ b/src/test/backport.test.ts
@@ -57,6 +57,26 @@ describe("find target branches", () => {
         )
       ).toEqual([]);
     });
+
+    it("when the label pattern only matches the headref", () => {
+      expect(
+        findTargetBranches(
+          { labels: { pattern: default_pattern } },
+          ["backport feature/one"],
+          "feature/one"
+        )
+      ).toEqual([]);
+    });
+
+    it("when target_branches only contains the headref", () => {
+      expect(
+        findTargetBranches(
+          { labels: {}, target_branches: "feature/one" },
+          [],
+          "feature/one"
+        )
+      ).toEqual([]);
+    });
   });
 
   describe("returns selected branches", () => {
@@ -117,6 +137,26 @@ describe("find target branches", () => {
           "feature/one"
         )
       ).toEqual(["release-1"]);
+    });
+
+    it("when several labels match the pattern the headref is excluded", () => {
+      expect(
+        findTargetBranches(
+          { labels: { pattern: default_pattern } },
+          ["backport feature/one", "backport feature/two"],
+          "feature/one"
+        )
+      ).toEqual(["feature/two"]);
+    });
+
+    it("when several target branches are specified the headref is excluded", () => {
+      expect(
+        findTargetBranches(
+          { labels: {}, target_branches: "feature/one feature/two" },
+          [],
+          "feature/one"
+        )
+      ).toEqual(["feature/two"]);
     });
   });
 });


### PR DESCRIPTION
This pull request enables users to select target branches more leniently.

When the action is triggered for a pull request, its headref should not be selected as target branch because it already contains the commits. There is no use case to cherry-pick the changes to that same branch again. However, it was possible to select the headref both through labels matching the `labels_pattern` input, as well as through the `target_branches` input. This pull request excludes the headref from any of the selected target branches automatically.

One example where this could be useful was highlighted in #343. While glob patterns are not supported in the target_branches input yet, it is possible to expand a glob pattern in a separate step, like:

```yml
- id: branches
  shell: bash
  # list all banches, filtering for 'feature/*', and cutting off remotes/origin/
  # then finally substitute newlines for spaces
  run: |
    branches=$(git branch --list --all | grep 'origin/feature/' | cut -c 18- )
    space_delimited=${branches//$'\n'/ }
    echo "BRANCHES=${space_delimited}" >> $GITHUB_OUTPUT
```

These branches can then be used as `target_branches` input. However, if the headref is among the selected branches, the action would unsuccessfully attempt to cherry-pick the changes of the pull request onto that same pull request's head. Git would rightfully complain about this. Now, that no longer occurs. 

closes #343 