### PR TITLE
Publish artifacts on release branches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Publish artifacts
         if: >
           github.ref == 'refs/heads/main'
-            || contains('refs/heads/release', github.ref)
+            || startsWith(github.ref, 'refs/heads/release')
         uses: EndBug/add-and-commit@v9
         with:
           commit: --signoff


### PR DESCRIPTION
The CI was supposed to publish artifacts on the main branch and on release branches. However, I misread the documentation for the `contains(search, item)` expression. I expected that search is the value to search for, while item is the thing to search in. It is actually the other way around: search is the thing to search in, and item is what is searched for.

In addition, contains might not be explicit enough. So for safeguarding it may be better to use `startsWith(searchString, searchValue)`. This function 'Returns true when searchString starts with searchValue'.

This problem should now be resolved.

We also need to backport this to v1.3 where the problem also exists. Before that release, there was no automated packaging and publishing of artifacts yet, so there is no need to backport it further down.