### PR TITLE
Fix formatting after update to prettier 3.0.0

### DIFF
--- a/src/backport.ts
+++ b/src/backport.ts
@@ -62,22 +62,22 @@ export class Backport {
       const target_branches = this.findTargetBranches(mainpr, this.config);
       if (target_branches.length === 0) {
         console.log(
-          `Nothing to backport: no 'target_branches' specified and none of the labels match the backport pattern '${this.config.labels.pattern?.source}'`
+          `Nothing to backport: no 'target_branches' specified and none of the labels match the backport pattern '${this.config.labels.pattern?.source}'`,
         );
         return; // nothing left to do here
       }
 
       console.log(
-        `Fetching all the commits from the pull request: ${mainpr.commits + 1}`
+        `Fetching all the commits from the pull request: ${mainpr.commits + 1}`,
       );
       await git.fetch(
         `refs/pull/${pull_number}/head`,
         this.config.pwd,
-        mainpr.commits + 1 // +1 in case this concerns a shallowly cloned repo
+        mainpr.commits + 1, // +1 in case this concerns a shallowly cloned repo
       );
 
       console.log(
-        "Determining first and last commit shas, so we can cherry-pick the commit range"
+        "Determining first and last commit shas, so we can cherry-pick the commit range",
       );
 
       const commitShas = await this.github.getCommits(mainpr);
@@ -92,11 +92,11 @@ export class Backport {
             (label) =>
               label.match(copyLabelsPattern) &&
               (this.config.labels.pattern === undefined ||
-                !label.match(this.config.labels.pattern))
+                !label.match(this.config.labels.pattern)),
           );
       }
       console.log(
-        `Will copy labels matching ${this.config.copy_labels_pattern}. Found matching labels: ${labelsToCopy}`
+        `Will copy labels matching ${this.config.copy_labels_pattern}. Found matching labels: ${labelsToCopy}`,
       );
 
       const successByTarget = new Map<string, boolean>();
@@ -134,7 +134,7 @@ export class Backport {
               3,
               baseref,
               headref,
-              branchname
+              branchname,
             );
             console.error(message);
             successByTarget.set(target, false);
@@ -155,7 +155,7 @@ export class Backport {
               4,
               baseref,
               headref,
-              branchname
+              branchname,
             );
             console.error(message);
             successByTarget.set(target, false);
@@ -173,7 +173,7 @@ export class Backport {
           if (pushExitCode != 0) {
             const message = this.composeMessageForGitPushFailure(
               target,
-              pushExitCode
+              pushExitCode,
             );
             console.error(message);
             successByTarget.set(target, false);
@@ -216,7 +216,7 @@ export class Backport {
           if (labelsToCopy.length > 0) {
             const label_response = await this.github.labelPR(
               new_pr.number,
-              labelsToCopy
+              labelsToCopy,
             );
             if (label_response.status != 200) {
               console.error(JSON.stringify(label_response));
@@ -256,7 +256,7 @@ export class Backport {
       } else {
         console.error(`An unexpected error occurred: ${JSON.stringify(error)}`);
         core.setFailed(
-          "An unexpected error occured. Please check the logs for details"
+          "An unexpected error occured. Please check the logs for details",
         );
       }
     }
@@ -271,12 +271,12 @@ export class Backport {
     const title = utils.replacePlaceholders(
       this.config.pull.title,
       main,
-      target
+      target,
     );
     const body = utils.replacePlaceholders(
       this.config.pull.description,
       main,
-      target
+      target,
     );
     return { title, body };
   }
@@ -291,7 +291,7 @@ export class Backport {
     exitcode: number,
     baseref: string,
     headref: string,
-    branchname: string
+    branchname: string,
   ): string {
     const reasons: { [key: number]: string } = {
       1: "due to an unknown script error",
@@ -324,14 +324,14 @@ export class Backport {
 
   private composeMessageForGitPushFailure(
     target: string,
-    exitcode: number
+    exitcode: number,
   ): string {
     //TODO better error messages depending on exit code
     return dedent`Git push to origin failed for ${target} with exitcode ${exitcode}`;
   }
 
   private composeMessageForCreatePRFailed(
-    response: CreatePullRequestResponse
+    response: CreatePullRequestResponse,
   ): string {
     return dedent`Backport branch created but failed to create PR. 
                 Request to create PR rejected with status ${response.status}.
@@ -346,13 +346,13 @@ export class Backport {
 
   private createOutput(successByTarget: Map<string, boolean>) {
     const anyTargetFailed = Array.from(successByTarget.values()).includes(
-      false
+      false,
     );
     core.setOutput(Output.wasSuccessful, !anyTargetFailed);
 
     const byTargetOutput = Array.from(successByTarget.entries()).reduce<string>(
       (i, [target, result]) => `${i}${target}=${result}\n`,
-      ""
+      "",
     );
     core.setOutput(Output.wasSuccessfulByTarget, byTargetOutput);
   }
@@ -361,7 +361,7 @@ export class Backport {
 export function findTargetBranches(
   config: Pick<Config, "labels" | "target_branches">,
   labels: string[],
-  headref: string
+  headref: string,
 ) {
   console.log("Determining target branches...");
 
@@ -376,10 +376,10 @@ export function findTargetBranches(
 
   console.log(`Found target branches in labels: ${targetBranchesFromLabels}`);
   console.log(
-    `Found target branches in \`target_branches\` input: ${configuredTargetBranches}`
+    `Found target branches in \`target_branches\` input: ${configuredTargetBranches}`,
   );
   console.log(
-    `Exclude pull request's headref from target branches: ${headref}`
+    `Exclude pull request's headref from target branches: ${headref}`,
   );
 
   const targetBranches = [
@@ -393,7 +393,7 @@ export function findTargetBranches(
 
 function findTargetBranchesFromLabels(
   labels: string[],
-  config: Pick<Config, "labels">
+  config: Pick<Config, "labels">,
 ) {
   const pattern = config.labels.pattern;
   if (pattern === undefined) {
@@ -406,13 +406,13 @@ function findTargetBranchesFromLabels(
     .filter((result) => {
       if (!result.match) {
         console.log(
-          `label '${result.label}' doesn't match \`label_pattern\` '${pattern.source}'`
+          `label '${result.label}' doesn't match \`label_pattern\` '${pattern.source}'`,
         );
       } else if (result.match.length < 2) {
         console.error(
           dedent`label '${result.label}' matches \`label_pattern\` '${pattern.source}', \
           but no branchname could be captured. Please make sure to provide a regex with a capture group as \
-          \`label_pattern\`.`
+          \`label_pattern\`.`,
         );
       }
       return !!result.match && result.match.length === 2;

--- a/src/git.ts
+++ b/src/git.ts
@@ -21,16 +21,16 @@ export async function fetch(ref: string, pwd: string, depth: number) {
   const { exitCode } = await git(
     "fetch",
     [`--depth=${depth}`, "origin", ref],
-    pwd
+    pwd,
   );
   if (exitCode === 128) {
     throw new GitRefNotFoundError(
       `Expected to fetch '${ref}', but couldn't find it`,
-      ref
+      ref,
     );
   } else if (exitCode !== 0) {
     throw new Error(
-      `'git fetch origin ${ref}' failed with exit code ${exitCode}`
+      `'git fetch origin ${ref}' failed with exit code ${exitCode}`,
     );
   }
 }
@@ -39,7 +39,7 @@ export async function push(branchname: string, pwd: string) {
   const { exitCode } = await git(
     "push",
     ["--set-upstream", "origin", branchname],
-    pwd
+    pwd,
   );
   return exitCode;
 }
@@ -62,7 +62,7 @@ export async function checkout(branch: string, start: string, pwd: string) {
   const { exitCode } = await git("switch", ["-c", branch, start], pwd);
   if (exitCode !== 0) {
     throw new Error(
-      `'git switch -c ${branch} ${start}' failed with exit code ${exitCode}`
+      `'git switch -c ${branch} ${start}' failed with exit code ${exitCode}`,
     );
   }
 }
@@ -72,7 +72,7 @@ export async function cherryPick(commitShas: string[], pwd: string) {
   if (exitCode !== 0) {
     await git("cherry-pick", ["--abort"], pwd);
     throw new Error(
-      `'git cherry-pick -x ${commitShas}' failed with exit code ${exitCode}`
+      `'git cherry-pick -x ${commitShas}' failed with exit code ${exitCode}`,
     );
   }
 }

--- a/src/github.ts
+++ b/src/github.ts
@@ -76,7 +76,7 @@ export class Github implements GithubApi {
   }
 
   public async getFirstAndLastCommitSha(
-    pull: PullRequest
+    pull: PullRequest,
   ): Promise<{ firstCommitSha: string; lastCommitSha: string | null }> {
     const commits = await this.getCommits(pull);
     return {

--- a/src/test/backport.test.ts
+++ b/src/test/backport.test.ts
@@ -13,8 +13,8 @@ describe("find target branches", () => {
         findTargetBranches(
           { labels: { pattern: default_pattern } },
           [],
-          "feature/one"
-        )
+          "feature/one",
+        ),
       ).toEqual([]);
     });
 
@@ -23,8 +23,8 @@ describe("find target branches", () => {
         findTargetBranches(
           { labels: { pattern: default_pattern } },
           ["a label", "another-label", "a/third/label"],
-          "feature/one"
-        )
+          "feature/one",
+        ),
       ).toEqual([]);
     });
 
@@ -33,8 +33,8 @@ describe("find target branches", () => {
         findTargetBranches(
           { labels: { pattern: /^no capture group$/ } },
           ["no capture group"],
-          "feature/one"
-        )
+          "feature/one",
+        ),
       ).toEqual([]);
     });
 
@@ -43,8 +43,8 @@ describe("find target branches", () => {
         findTargetBranches(
           { labels: { pattern: undefined } },
           ["an empty string"],
-          "feature/one"
-        )
+          "feature/one",
+        ),
       ).toEqual([]);
     });
 
@@ -53,8 +53,8 @@ describe("find target branches", () => {
         findTargetBranches(
           { labels: { pattern: default_pattern }, target_branches: "" },
           ["a label"],
-          "feature/one"
-        )
+          "feature/one",
+        ),
       ).toEqual([]);
     });
 
@@ -63,8 +63,8 @@ describe("find target branches", () => {
         findTargetBranches(
           { labels: { pattern: default_pattern } },
           ["backport feature/one"],
-          "feature/one"
-        )
+          "feature/one",
+        ),
       ).toEqual([]);
     });
 
@@ -73,8 +73,8 @@ describe("find target branches", () => {
         findTargetBranches(
           { labels: {}, target_branches: "feature/one" },
           [],
-          "feature/one"
-        )
+          "feature/one",
+        ),
       ).toEqual([]);
     });
   });
@@ -85,8 +85,8 @@ describe("find target branches", () => {
         findTargetBranches(
           { labels: { pattern: default_pattern } },
           ["backport release-1"],
-          "feature/one"
-        )
+          "feature/one",
+        ),
       ).toEqual(["release-1"]);
     });
 
@@ -95,8 +95,8 @@ describe("find target branches", () => {
         findTargetBranches(
           { labels: { pattern: default_pattern } },
           ["backport release-1", "backport another/target/branch"],
-          "feature/one"
-        )
+          "feature/one",
+        ),
       ).toEqual(["release-1", "another/target/branch"]);
     });
 
@@ -108,8 +108,8 @@ describe("find target branches", () => {
             target_branches: "release-1",
           },
           [],
-          "feature/one"
-        )
+          "feature/one",
+        ),
       ).toEqual(["release-1"]);
     });
 
@@ -121,8 +121,8 @@ describe("find target branches", () => {
             target_branches: "release-1 another/target/branch",
           },
           [],
-          "feature/one"
-        )
+          "feature/one",
+        ),
       ).toEqual(["release-1", "another/target/branch"]);
     });
 
@@ -134,8 +134,8 @@ describe("find target branches", () => {
             target_branches: "release-1",
           },
           ["backport release-1"],
-          "feature/one"
-        )
+          "feature/one",
+        ),
       ).toEqual(["release-1"]);
     });
 
@@ -144,8 +144,8 @@ describe("find target branches", () => {
         findTargetBranches(
           { labels: { pattern: default_pattern } },
           ["backport feature/one", "backport feature/two"],
-          "feature/one"
-        )
+          "feature/one",
+        ),
       ).toEqual(["feature/two"]);
     });
 
@@ -154,8 +154,8 @@ describe("find target branches", () => {
         findTargetBranches(
           { labels: {}, target_branches: "feature/one feature/two" },
           [],
-          "feature/one"
-        )
+          "feature/one",
+        ),
       ).toEqual(["feature/two"]);
     });
   });

--- a/src/test/utils.test.ts
+++ b/src/test/utils.test.ts
@@ -21,15 +21,15 @@ describe("get mentioned issues", () => {
 
     it("for a text with an external issue reference as part of a word", () => {
       expect(
-        getMentionedIssueRefs(text({ part: "zeebe-io/zeebe#123" }))
+        getMentionedIssueRefs(text({ part: "zeebe-io/zeebe#123" })),
       ).toHaveLength(0);
     });
 
     it("for a text with an issue url as part of a word", () => {
       expect(
         getMentionedIssueRefs(
-          text({ part: "github.com/zeebe-io/backport-action/issues/123" })
-        )
+          text({ part: "github.com/zeebe-io/backport-action/issues/123" }),
+        ),
       ).toHaveLength(0);
     });
   });
@@ -47,39 +47,39 @@ describe("get mentioned issues", () => {
 
     it("for a text with an external issue reference at the start", () => {
       expect(
-        getMentionedIssueRefs(text({ start: "zeebe-io/zeebe#123" }))
+        getMentionedIssueRefs(text({ start: "zeebe-io/zeebe#123" })),
       ).toEqual(["zeebe-io/zeebe#123"]);
     });
     it("for a text with an external issue reference in the middle", () => {
       expect(
-        getMentionedIssueRefs(text({ middle: "zeebe-io/zeebe#123" }))
+        getMentionedIssueRefs(text({ middle: "zeebe-io/zeebe#123" })),
       ).toEqual(["zeebe-io/zeebe#123"]);
     });
     it("for a text with an external issue reference at the end", () => {
       expect(
-        getMentionedIssueRefs(text({ end: "zeebe-io/zeebe#123" }))
+        getMentionedIssueRefs(text({ end: "zeebe-io/zeebe#123" })),
       ).toEqual(["zeebe-io/zeebe#123"]);
     });
 
     it("for a text with an issue url at the start", () => {
       expect(
         getMentionedIssueRefs(
-          text({ start: "github.com/zeebe-io/backport-action/issues/123/" })
-        )
+          text({ start: "github.com/zeebe-io/backport-action/issues/123/" }),
+        ),
       ).toEqual(["zeebe-io/backport-action#123"]);
     });
     it("for a text with an issue url in the middle", () => {
       expect(
         getMentionedIssueRefs(
-          text({ middle: "github.com/zeebe-io/backport-action/issues/123" })
-        )
+          text({ middle: "github.com/zeebe-io/backport-action/issues/123" }),
+        ),
       ).toEqual(["zeebe-io/backport-action#123"]);
     });
     it("for a text with an issue url at the end", () => {
       expect(
         getMentionedIssueRefs(
-          text({ end: "github.com/zeebe-io/backport-action/issues/123" })
-        )
+          text({ end: "github.com/zeebe-io/backport-action/issues/123" }),
+        ),
       ).toEqual(["zeebe-io/backport-action#123"]);
     });
   });
@@ -88,8 +88,8 @@ describe("get mentioned issues", () => {
     it("for a text with an issue reference at the start, middle and end", () => {
       expect(
         getMentionedIssueRefs(
-          text({ start: "#123", middle: "#234", end: "#345" })
-        )
+          text({ start: "#123", middle: "#234", end: "#345" }),
+        ),
       ).toEqual(["#123", "#234", "#345"]);
     });
     it("for a text with an external issue reference at the start, middle and end", () => {
@@ -99,8 +99,8 @@ describe("get mentioned issues", () => {
             start: "zeebe-io/zeebe#123",
             middle: "zeebe-io/zeebe#234",
             end: "zeebe-io/zeebe#345",
-          })
-        )
+          }),
+        ),
       ).toEqual([
         "zeebe-io/zeebe#123",
         "zeebe-io/zeebe#234",
@@ -111,8 +111,12 @@ describe("get mentioned issues", () => {
       const base = "github.com/zeebe-io/backport-action/issues/";
       expect(
         getMentionedIssueRefs(
-          text({ start: `${base}123`, middle: `${base}234`, end: `${base}345` })
-        )
+          text({
+            start: `${base}123`,
+            middle: `${base}234`,
+            end: `${base}345`,
+          }),
+        ),
       ).toEqual([
         "zeebe-io/backport-action#123",
         "zeebe-io/backport-action#234",
@@ -123,8 +127,12 @@ describe("get mentioned issues", () => {
       const base = "github.com/zeebe-io/zeebe/issues/";
       expect(
         getMentionedIssueRefs(
-          text({ start: `${base}123`, middle: `${base}234`, end: `${base}345` })
-        )
+          text({
+            start: `${base}123`,
+            middle: `${base}234`,
+            end: `${base}345`,
+          }),
+        ),
       ).toEqual([
         "zeebe-io/zeebe#123",
         "zeebe-io/zeebe#234",
@@ -151,7 +159,7 @@ describe("compose body/title", () => {
     it("for a template without placeholders", () => {
       const template = text({});
       expect(replacePlaceholders(template, main_default, target)).toEqual(
-        template
+        template,
       );
     });
 
@@ -163,7 +171,7 @@ describe("compose body/title", () => {
         part: "${jkl}",
       });
       expect(replacePlaceholders(template, main_default, target)).toEqual(
-        template
+        template,
       );
     });
   });
@@ -172,21 +180,21 @@ describe("compose body/title", () => {
     it("for a template with target_branch placeholder", () => {
       const template = "Backport of some-title to `${target_branch}`";
       expect(replacePlaceholders(template, main_default, target)).toEqual(
-        "Backport of some-title to `foo-target`"
+        "Backport of some-title to `foo-target`",
       );
     });
 
     it("for a template with pull_number placeholder", () => {
       const template = "Backport of #${pull_number} to some-target";
       expect(replacePlaceholders(template, main_default, target)).toEqual(
-        "Backport of #123 to some-target"
+        "Backport of #123 to some-target",
       );
     });
 
     it("for a template with pull_title placeholder", () => {
       const template = "Backport of ${pull_title} to some-target";
       expect(replacePlaceholders(template, main_default, target)).toEqual(
-        "Backport of some pr title to some-target"
+        "Backport of some pr title to some-target",
       );
     });
 
@@ -195,7 +203,7 @@ describe("compose body/title", () => {
 
       it("and body has no referred issues", () => {
         expect(replacePlaceholders(template, main_default, target)).toEqual(
-          "Backport that refers to: "
+          "Backport that refers to: ",
         );
       });
 
@@ -207,8 +215,8 @@ describe("compose body/title", () => {
               ...main_default,
               body: "Body mentions #123 and that's it.",
             },
-            target
-          )
+            target,
+          ),
         ).toEqual("Backport that refers to: #123");
       });
 
@@ -220,8 +228,8 @@ describe("compose body/title", () => {
               ...main_default,
               body: "This body refers to #123 and foo/bar#456",
             },
-            target
-          )
+            target,
+          ),
         ).toEqual("Backport that refers to: #123 foo/bar#456");
       });
     });
@@ -229,7 +237,7 @@ describe("compose body/title", () => {
     it("for a template with pull_author placeholder", () => {
       const template = "Backport of pull made by @${pull_author}";
       expect(replacePlaceholders(template, main_default, target)).toEqual(
-        "Backport of pull made by @foo-author"
+        "Backport of pull made by @foo-author",
       );
     });
   });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -9,7 +9,7 @@ import { PullRequest } from "./github";
 export function replacePlaceholders(
   template: string,
   main: Pick<PullRequest, "body" | "user" | "number" | "title">,
-  target: string
+  target: string,
 ): string {
   const issues = getMentionedIssueRefs(main.body);
   return template
@@ -56,7 +56,7 @@ const toRef = (url: string) => {
   const result = patterns.url.first.exec(url);
   if (!result) {
     console.error(
-      `Expected to transform url (${url}) to GitHub reference, but it did not match pattern'`
+      `Expected to transform url (${url}) to GitHub reference, but it did not match pattern'`,
     );
     return "";
   }


### PR DESCRIPTION
Prettier was updated with #350 and passed the CI, but it shouldn't have because the formatting changed.

The CI ran:
```
npm run format-check

> backport-action@1.4.0-SNAPSHOT format-check
> prettier --check "**.ts"

Checking formatting...
All matched files use Prettier code style!
```

And after merging, this failed locally.