### PR TITLE
Revert "build(deps-dev): bump prettier from 2.8.8 to 3.0.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "backport-action",
-  "version": "1.4.0-SNAPSHOT",
+  "version": "1.3.0-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "backport-action",
-      "version": "1.4.0-SNAPSHOT",
+      "version": "1.3.0-SNAPSHOT",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",
@@ -19,7 +19,7 @@
         "@types/jest": "^27.5.0",
         "@vercel/ncc": "^0.36.1",
         "jest": "^27.5.1",
-        "prettier": "3.0.0",
+        "prettier": "2.8.8",
         "ts-jest": "^27.1.2",
         "typescript": "^4.9.5"
       }
@@ -3740,15 +3740,15 @@
       }
     },
     "node_modules/prettier": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.0.0.tgz",
-      "integrity": "sha512-zBf5eHpwHOGPC47h0zrPyNn+eAEIdEzfywMoYn2XPi0P44Zp0tSq64rq0xAREh4auw2cJZHo9QUob+NqCQky4g==",
+      "version": "2.8.8",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.8.tgz",
+      "integrity": "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==",
       "dev": true,
       "bin": {
-        "prettier": "bin/prettier.cjs"
+        "prettier": "bin-prettier.js"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=10.13.0"
       },
       "funding": {
         "url": "https://github.com/prettier/prettier?sponsor=1"

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "@types/jest": "^27.5.0",
     "@vercel/ncc": "^0.36.1",
     "jest": "^27.5.1",
-    "prettier": "3.0.0",
+    "prettier": "2.8.8",
     "ts-jest": "^27.1.2",
     "typescript": "^4.9.5"
   }


### PR DESCRIPTION
Reverts korthout/backport-action#350

This is necessary because the CI doesn't pass on #351 while it also doesn't pass on `main` without #351.