### PR TITLE
ci: run on pull_request

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - main
       - release*
-  pull_request_target: { }
+  pull_request: { }
 
 jobs:
   build:
@@ -33,8 +33,10 @@ jobs:
           CI: true
       - name: Publish artifacts
         if: >
-          github.ref == 'refs/heads/main'
-            || startsWith(github.ref, 'refs/heads/release')
+          github.event_name == 'push' && (
+            github.ref == 'refs/heads/main' ||
+            startsWith(github.ref, 'refs/heads/release')
+          )
         uses: EndBug/add-and-commit@v9
         with:
           commit: --signoff


### PR DESCRIPTION
pull_request_target is run in the context of the pull request's base, which makes sense because secrets are made available. But, it meant that the checked out code that was tested was also just that from the base, and not that of the pull request.

To avoid this, I could checkout the code from the pull request's head, but that is dangerous as it may expose secrets to malicious actors.

Instead, its better to just revert to running on pull_request instead.