### PR TITLE
ci: run ci workflow on pr closed

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,8 @@
 name: CI
 
 on:
-  pull_request: { }
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
 
 jobs:
   build:


### PR DESCRIPTION
This is necessary to not skip the last steps when the pull request is actually merged.