### PR TITLE
ci: publish artifacts after merging

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,13 +26,15 @@ jobs:
         run: npm run test-verbose
         env:
           CI: true
+      - name: Prepare post-merge steps
+        if: >
+          github.event.action == 'closed' &&
+          github.event.pull_request.merged
+        run: git checkout ${{ github.event.pull_request.base.ref }}
       - name: Publish artifacts
         if: >
           github.event.action == 'closed' &&
-          github.event.pull_request.merged && (
-            github.ref == 'refs/heads/main' ||
-            startsWith(github.ref, 'refs/heads/release')
-          )
+          github.event.pull_request.merged
         uses: EndBug/add-and-commit@v9
         with:
           commit: --signoff
@@ -44,8 +46,8 @@ jobs:
         if: >
           github.event.action == 'closed' &&
           github.event.pull_request.merged && (
-            github.ref == 'refs/heads/main' ||
-            startsWith(github.ref, 'refs/heads/release')
+            github.event.pull_request.base.ref == 'refs/heads/main' ||
+            startsWith(github.event.pull_request.base.ref, 'refs/heads/release')
           )
         run: |
           git tag v1.next-preview --force


### PR DESCRIPTION
So after all the recent changes, I forgot to adjust the references used to decide whether the artifacts are published and whether the release-next tag is moved.

These refs should be those of the pull_request base (like main and release). Additionally, I just realized that I only have to check these for the move next preview tag step. The artifacts can always be build when the pull request is merged.

However, this made me realize that the artifacts should be published by commit (and pushing) to the pull request's base ref as well. Not to the pull request's head.