### PR TITLE
ci: remove ref prefix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,8 +46,8 @@ jobs:
         if: >
           github.event.action == 'closed' &&
           github.event.pull_request.merged && (
-            github.event.pull_request.base.ref == 'refs/heads/main' ||
-            startsWith(github.event.pull_request.base.ref, 'refs/heads/release')
+            github.event.pull_request.base.ref == 'main' ||
+            startsWith(github.event.pull_request.base.ref, 'release')
           )
         run: |
           git tag v1.next-preview --force


### PR DESCRIPTION
The ref in the event payload (pull_request.base.ref) doesn't have the same prefix of the ref like github.ref does. Let's remove this.