### PR TITLE
Update from node16 to node20

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Use Node.js 16.x
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: 16.x
           cache: 'npm'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,5 +50,5 @@ jobs:
             startsWith(github.event.pull_request.base.ref, 'release')
           )
         run: |
-          git tag v1.next-preview --force
-          git push origin v1.next-preview --force
+          git tag v2.next-preview --force
+          git push origin v2.next-preview --force

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,10 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - name: Use Node.js 16.x
+      - name: Use Node.js 20.x
         uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 20.x
           cache: 'npm'
       - name: Install dependencies
         run: npm ci

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,14 +69,6 @@ jobs:
           git push origin v${{ steps.version.outputs.major }} --force
           git push origin v${{ steps.version.outputs.major }}.${{ steps.version.outputs.minor }} --force
 
-      - name: Update release-next-preview workflow
-        uses: jacobtomlinson/gha-find-replace@v3
-        with:
-          find: 'v(\d+)\.next-preview'
-          replace: 'v${{ steps.version.outputs.major }}.next-preview'
-          include: ".github/workflows/release-next-preview.yml"
-          regex: true
-
       - name: Commit next development version
         id: commit-next-dev
         uses: EndBug/add-and-commit@v9

--- a/action.yml
+++ b/action.yml
@@ -63,7 +63,7 @@ outputs:
       Whether or not the changes could be backported successfully to all targets - broken down by target.
       Follows the pattern '{{label}}=true|false'.
 runs:
-  using: "node16"
+  using: "node20"
   main: "dist/index.js"
 branding:
   icon: 'copy'

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "backport-action",
-  "version": "1.5.0-SNAPSHOT",
+  "version": "2.0.0-SNAPSHOT",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "backport-action",
-  "version": "1.5.0-SNAPSHOT",
+  "version": "2.0.0-SNAPSHOT",
   "private": false,
   "description": "GitHub action to automatically backport pull requests",
   "main": "lib/main.js",


### PR DESCRIPTION
This is needed because node16 is end-of-life. 

See: https://github.com/nodejs/release#release-schedule
See: https://nodejs.org/en/blog/announcements/nodejs16-eol

Since this drops support for node16, it is a breaking change and requires us to move to `v2`.