### PR TITLE
feat: add support for milestone, assignees and reviewers

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,12 +127,13 @@ Default: `false` (disabled)
 Controls whether to copy the milestone from the original pull request to the backport pull request.
 By default, the milestone is not copied.
 
-### `copy_reviewers`
+### `copy_requested_reviewers`
 
 Default: `false` (disabled)
 
-Controls whether to copy the reviewers from the original pull request to the backport pull request.
-By default, the reviewers are not copied.
+Controls whether to copy the requested reviewers from the original pull request to the backport pull request.
+Note that this does not request reviews from those users who already reviewed the original pull request.
+By default, the requested reviewers are not copied.
 
 ### `github_token`
 

--- a/README.md
+++ b/README.md
@@ -109,7 +109,8 @@ The action can be configured with the following optional [inputs](https://docs.g
 
 Default: `false` (disabled)
 
-Controls wheather the assignees of the original pull request should be added to the backports.
+Controls whether to copy the assignees from the original pull request to the backport pull request.
+By default, the assignees are not copied.
 
 ### `copy_labels_pattern`
 
@@ -123,13 +124,15 @@ By default, no labels are copied.
 
 Default: `false` (disabled)
 
-Controls wheather the "milestone" of the original pull request should be added to the backports.
+Controls whether to copy the milestone from the original pull request to the backport pull request.
+By default, the milestone is not copied.
 
 ### `copy_reviewers`
 
 Default: `false` (disabled)
 
-Controls wheather the reviewers of the original pull request should be added to the backports.
+Controls whether to copy the reviewers from the original pull request to the backport pull request.
+By default, the reviewers are not copied.
 
 ### `github_token`
 

--- a/README.md
+++ b/README.md
@@ -105,6 +105,12 @@ jobs:
 
 The action can be configured with the following optional [inputs](https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepswith):
 
+### `copy_assignees`
+
+Default: `''` (disabled)
+
+Controls wheather the assignees of the original pull request should be added to the backports.
+
 ### `copy_labels_pattern`
 
 Default: `''` (disabled)
@@ -112,6 +118,18 @@ Default: `''` (disabled)
 Regex pattern to match github labels which will be copied from the original pull request to the backport pull request.
 Note that labels matching `label_pattern` are excluded.
 By default, no labels are copied.
+
+### `copy_milestone`
+
+Default: `''` (disabled)
+
+Controls wheather the "milestone" of the original pull request should be added to the backports.
+
+### `copy_reviewers`
+
+Default: `''` (disabled)
+
+Controls wheather the reviewers of the original pull request should be added to the backports.
 
 ### `github_token`
 
@@ -184,26 +202,6 @@ See [How it works](#how-it-works).
 
 Can be used in addition to backport labels.
 By default, only backport labels are used to specify the target branches.
-
-
-### `copy_milestone`
-
-Default: `''` (disabled)
-
-Controls wheather the "milestone" of the original pull request should be added to the backports.
-
-### `copy_assignees`
-
-Default: `''` (disabled)
-
-Controls wheather the assignees of the original pull request should be added to the backports.
-
-### `copy_reviewers`
-
-Default: `''` (disabled)
-
-Controls wheather the reviewers of the original pull request should be added to the backports.
-
 
 ## Placeholders
 In the `pull_description` and `pull_title` inputs, placeholders can be used to define variable values.

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ The action can be configured with the following optional [inputs](https://docs.g
 
 ### `copy_assignees`
 
-Default: `''` (disabled)
+Default: `false` (disabled)
 
 Controls wheather the assignees of the original pull request should be added to the backports.
 
@@ -121,13 +121,13 @@ By default, no labels are copied.
 
 ### `copy_milestone`
 
-Default: `''` (disabled)
+Default: `false` (disabled)
 
 Controls wheather the "milestone" of the original pull request should be added to the backports.
 
 ### `copy_reviewers`
 
-Default: `''` (disabled)
+Default: `false` (disabled)
 
 Controls wheather the reviewers of the original pull request should be added to the backports.
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # Only run when pull request is merged
-    # or when a comment containing `/backport` is created by someone other than the 
+    # or when a comment containing `/backport` is created by someone other than the
     # https://github.com/backport-action bot user (user id: 97796249). Note that if you use your
     # own PAT as `github_token`, that you should replace this id with yours.
     if: >
@@ -184,6 +184,26 @@ See [How it works](#how-it-works).
 
 Can be used in addition to backport labels.
 By default, only backport labels are used to specify the target branches.
+
+
+### `copy_milestone`
+
+Default: `''` (disabled)
+
+Controls wheather the "milestone" of the original pull request should be added to the backports.
+
+### `copy_assignees`
+
+Default: `''` (disabled)
+
+Controls wheather the assignees of the original pull request should be added to the backports.
+
+### `copy_reviewers`
+
+Default: `''` (disabled)
+
+Controls wheather the reviewers of the original pull request should be added to the backports.
+
 
 ## Placeholders
 In the `pull_description` and `pull_title` inputs, placeholders can be used to define variable values.

--- a/action.yml
+++ b/action.yml
@@ -3,11 +3,23 @@ description: >
   Fast and flexible action to cherry-pick commits from labeled pull requests
 author: korthout
 inputs:
+  copy_assignees:
+    description: >
+      Whether or not to copy the assignees from the original pull request to the backport pull request.
+      By default, the assignees are not copied.
   copy_labels_pattern:
     description: >
       Regex pattern to match github labels which will be copied from the original pull request to the backport pull request.
       Note that labels matching `label_pattern` are excluded.
       By default, no labels are copied.
+  copy_milestone:
+    description: >
+      Whether or not to copy the milestone from the original pull request to the backport pull request.
+      By default, the milestone is not copied.
+  copy_reviewers:
+    description: >
+      Whether or not to copy the reviewers from the original pull request to the backport pull request.
+      By default, the reviewers are not copied.
   github_token:
     description: >
       Token to authenticate requests to GitHub.
@@ -53,18 +65,6 @@ inputs:
       Note that the pull request's headref is excluded automatically.
       Can be used in addition to backport labels.
       By default, only backport labels are used to specify the target branches.
-  copy_milestone:
-    description: >
-      Whether or not to copy the milestone from the original pull request to the backport pull request.
-      By default, the milestone is not copied.
-  copy_assignees:
-    description: >
-      Whether or not to copy the assignees from the original pull request to the backport pull request.
-      By default, the assignees are not copied.
-  copy_reviewers:
-    description: >
-      Whether or not to copy the reviewers from the original pull request to the backport pull request.
-      By default, the reviewers are not copied.
 outputs:
   was_successful:
     description: >

--- a/action.yml
+++ b/action.yml
@@ -53,6 +53,18 @@ inputs:
       Note that the pull request's headref is excluded automatically.
       Can be used in addition to backport labels.
       By default, only backport labels are used to specify the target branches.
+  copy_milestone:
+    description: >
+      Whether or not to copy the milestone from the original pull request to the backport pull request.
+      By default, the milestone is not copied.
+  copy_assignees:
+    description: >
+      Whether or not to copy the assignees from the original pull request to the backport pull request.
+      By default, the assignees are not copied.
+  copy_reviewers:
+    description: >
+      Whether or not to copy the reviewers from the original pull request to the backport pull request.
+      By default, the reviewers are not copied.
 outputs:
   was_successful:
     description: >

--- a/action.yml
+++ b/action.yml
@@ -5,7 +5,7 @@ author: korthout
 inputs:
   copy_assignees:
     description: >
-      Whether or not to copy the assignees from the original pull request to the backport pull request.
+      Controls whether to copy the assignees from the original pull request to the backport pull request.
       By default, the assignees are not copied.
     default: false
   copy_labels_pattern:
@@ -15,12 +15,12 @@ inputs:
       By default, no labels are copied.
   copy_milestone:
     description: >
-      Whether or not to copy the milestone from the original pull request to the backport pull request.
+      Controls whether to copy the milestone from the original pull request to the backport pull request.
       By default, the milestone is not copied.
     default: false
   copy_reviewers:
     description: >
-      Whether or not to copy the reviewers from the original pull request to the backport pull request.
+      Controls whether to copy the reviewers from the original pull request to the backport pull request.
       By default, the reviewers are not copied.
     default: false
   github_token:

--- a/action.yml
+++ b/action.yml
@@ -7,6 +7,7 @@ inputs:
     description: >
       Whether or not to copy the assignees from the original pull request to the backport pull request.
       By default, the assignees are not copied.
+    default: false
   copy_labels_pattern:
     description: >
       Regex pattern to match github labels which will be copied from the original pull request to the backport pull request.
@@ -16,10 +17,12 @@ inputs:
     description: >
       Whether or not to copy the milestone from the original pull request to the backport pull request.
       By default, the milestone is not copied.
+    default: false
   copy_reviewers:
     description: >
       Whether or not to copy the reviewers from the original pull request to the backport pull request.
       By default, the reviewers are not copied.
+    default: false
   github_token:
     description: >
       Token to authenticate requests to GitHub.

--- a/action.yml
+++ b/action.yml
@@ -18,10 +18,11 @@ inputs:
       Controls whether to copy the milestone from the original pull request to the backport pull request.
       By default, the milestone is not copied.
     default: false
-  copy_reviewers:
+  copy_requested_reviewers:
     description: >
-      Controls whether to copy the reviewers from the original pull request to the backport pull request.
-      By default, the reviewers are not copied.
+      Controls whether to copy the requested reviewers from the original pull request to the backport pull request.
+      Note that this does not request reviews from those users who already reviewed the original pull request.
+      By default, the requested reviewers are not copied.
     default: false
   github_token:
     description: >

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -25,6 +25,9 @@ export type Config = {
   commits: {
     merge_commits: "fail" | "skip";
   };
+  copy_milestone: boolean;
+  copy_assignees: boolean;
+  copy_reviewers: boolean;
 };
 
 enum Output {
@@ -257,6 +260,54 @@ export class Backport {
           }
           const new_pr = new_pr_response.data;
 
+          if (this.config.copy_milestone == true) {
+            const milestone = mainpr.milestone?.number;
+            if (milestone) {
+              console.info("Setting milestone to " + milestone);
+              const set_milestone_response = await this.github.setMilestone(
+                new_pr.number,
+                milestone,
+              );
+              if (set_milestone_response.status != 200) {
+                console.error(set_milestone_response.status);
+                console.error(JSON.stringify(set_milestone_response));
+              }
+            }
+          }
+
+          if (this.config.copy_assignees == true) {
+            const assignees = mainpr.assignees.map((label) => label.login);
+            if (assignees.length > 0) {
+              console.info("Setting assignees " + assignees);
+              const set_assignee_response = await this.github.setAssignees(
+                new_pr.number,
+                assignees,
+              );
+              if (set_assignee_response.status != 201) {
+                console.error(set_assignee_response.status);
+              }
+            }
+          }
+
+          if (this.config.copy_reviewers == true) {
+            const reviewers = mainpr.requested_reviewers?.map(
+              (reviewer) => reviewer.login,
+            );
+            if (reviewers?.length > 0) {
+              console.info("Setting reviewers " + reviewers);
+              const reviewRequest = {
+                ...this.github.getRepo(),
+                pull_number: new_pr.number,
+                reviewers: reviewers,
+              };
+              const set_reviewers_response =
+                await this.github.requestReviewers(reviewRequest);
+              if (set_reviewers_response.status != 201) {
+                console.error(set_reviewers_response.status);
+              }
+            }
+          }
+
           if (labelsToCopy.length > 0) {
             const label_response = await this.github.labelPR(
               new_pr.number,
@@ -305,6 +356,7 @@ export class Backport {
       }
     }
   }
+
 
   private findTargetBranches(mainpr: PullRequest, config: Config): string[] {
     const labels = mainpr.labels.map((label) => label.name);
@@ -377,7 +429,7 @@ export class Backport {
   private composeMessageForCreatePRFailed(
     response: CreatePullRequestResponse,
   ): string {
-    return dedent`Backport branch created but failed to create PR. 
+    return dedent`Backport branch created but failed to create PR.
                 Request to create PR rejected with status ${response.status}.
 
                 (see action log for full response)`;

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -27,7 +27,7 @@ export type Config = {
   };
   copy_milestone: boolean;
   copy_assignees: boolean;
-  copy_reviewers: boolean;
+  copy_requested_reviewers: boolean;
 };
 
 enum Output {
@@ -289,7 +289,7 @@ export class Backport {
             }
           }
 
-          if (this.config.copy_reviewers == true) {
+          if (this.config.copy_requested_reviewers == true) {
             const reviewers = mainpr.requested_reviewers?.map(
               (reviewer) => reviewer.login,
             );

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -356,7 +356,6 @@ export class Backport {
     }
   }
 
-
   private findTargetBranches(mainpr: PullRequest, config: Config): string[] {
     const labels = mainpr.labels.map((label) => label.name);
     return findTargetBranches(config, labels, mainpr.head.ref);

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -269,7 +269,6 @@ export class Backport {
                 milestone,
               );
               if (set_milestone_response.status != 200) {
-                console.error(set_milestone_response.status);
                 console.error(JSON.stringify(set_milestone_response));
               }
             }
@@ -284,7 +283,7 @@ export class Backport {
                 assignees,
               );
               if (set_assignee_response.status != 201) {
-                console.error(set_assignee_response.status);
+                console.error(JSON.stringify(set_assignee_response));
               }
             }
           }
@@ -303,7 +302,7 @@ export class Backport {
               const set_reviewers_response =
                 await this.github.requestReviewers(reviewRequest);
               if (set_reviewers_response.status != 201) {
-                console.error(set_reviewers_response.status);
+                console.error(JSON.stringify(set_reviewers_response));
               }
             }
           }

--- a/src/github.ts
+++ b/src/github.ts
@@ -20,6 +20,8 @@ export interface GithubApi {
   createPR(pr: CreatePullRequest): Promise<CreatePullRequestResponse>;
   labelPR(pr: number, labels: string[]): Promise<LabelPullRequestResponse>;
   requestReviewers(request: ReviewRequest): Promise<RequestReviewersResponse>;
+  setAssignees(pr: number, assignees: string[]): Promise<GenericResponse>;
+  setMilestone(pr: number, milestone: number): Promise<GenericResponse>;
 }
 
 export class Github implements GithubApi {
@@ -126,6 +128,24 @@ export class Github implements GithubApi {
       labels,
     });
   }
+
+  public async setAssignees(pr: number, assignees: string[]) {
+    console.log(`Set Assignees ${assignees} to #${pr}`);
+    return this.#octokit.rest.issues.addAssignees({
+      ...this.getRepo(),
+      issue_number: pr,
+      assignees,
+    });
+  }
+
+  public async setMilestone(pr: number, milestone: number) {
+    console.log(`Set Milestone ${milestone} to #${pr}`);
+    return this.#octokit.rest.issues.update({
+      ...this.getRepo(),
+      issue_number: pr,
+      milestone: milestone,
+    });
+  }
 }
 
 export type PullRequest = {
@@ -149,6 +169,18 @@ export type PullRequest = {
     login: string;
   }[];
   commits: number;
+  milestone: {
+    number: number;
+    id: number;
+    title: string;
+  };
+  assignees: {
+    login: string;
+    id: number;
+  }[];
+  merged_by: {
+    login: string;
+  };
 };
 export type CreatePullRequestResponse = {
   status: number;
@@ -158,6 +190,11 @@ export type CreatePullRequestResponse = {
   };
 };
 export type RequestReviewersResponse = CreatePullRequestResponse;
+
+export type GenericResponse = {
+  status: number;
+};
+
 export type LabelPullRequestResponse = {
   status: number;
 };

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,7 +20,7 @@ async function run(): Promise<void> {
   const merge_commits = core.getInput("merge_commits");
   const copy_assignees = core.getInput("copy_assignees");
   const copy_milestone = core.getInput("copy_milestone");
-  const copy_reviewers = core.getInput("copy_reviewers");
+  const copy_requested_reviewers = core.getInput("copy_requested_reviewers");
 
   if (merge_commits != "fail" && merge_commits != "skip") {
     const message = `Expected input 'merge_commits' to be either 'fail' or 'skip', but was '${merge_commits}'`;
@@ -41,7 +41,7 @@ async function run(): Promise<void> {
     commits: { merge_commits },
     copy_assignees: copy_assignees === "true",
     copy_milestone: copy_milestone === "true",
-    copy_reviewers: copy_reviewers === "true",
+    copy_requested_reviewers: copy_requested_reviewers === "true",
   };
   const backport = new Backport(github, config, git);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -18,6 +18,9 @@ async function run(): Promise<void> {
   const copy_labels_pattern = core.getInput("copy_labels_pattern");
   const target_branches = core.getInput("target_branches");
   const merge_commits = core.getInput("merge_commits");
+  const copy_assignees = core.getInput("copy_assignees");
+  const copy_milestone = core.getInput("copy_milestone");
+  const copy_reviewers = core.getInput("copy_reviewers");
 
   if (merge_commits != "fail" && merge_commits != "skip") {
     const message = `Expected input 'merge_commits' to be either 'fail' or 'skip', but was '${merge_commits}'`;
@@ -36,6 +39,9 @@ async function run(): Promise<void> {
       copy_labels_pattern === "" ? undefined : new RegExp(copy_labels_pattern),
     target_branches: target_branches === "" ? undefined : target_branches,
     commits: { merge_commits },
+    copy_assignees: copy_assignees === "true",
+    copy_milestone: copy_milestone === "true",
+    copy_reviewers: copy_reviewers === "true",
   };
   const backport = new Backport(github, config, git);
 


### PR DESCRIPTION
@korthout This patch intends to add three new config options:

1. `copy_milestone`

   Copies the milestone from the original PR to all its backport PRs.

2. `copy_reviewers`

   Assigns the same reviewers to the backport PRs as were on the original PR.

3. `copy_assignees`  

   Assigns the same individuals to the backport PRs as were assigned to the original PR.


All of these options are disabled by default.


Addresses: https://github.com/korthout/backport-action/issues/2