### PR TITLE
Skip merge commits in suggestion

### DIFF
--- a/src/backport.ts
+++ b/src/backport.ts
@@ -404,7 +404,7 @@ export class Backport {
     );
     return dedent`Backport failed for \`${target}\`, ${reason}.
 
-                  Please cherry-pick the changes locally.
+                  Please cherry-pick the changes locally and resolve any conflicts.
                   ${suggestion}`;
   }
 

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -417,7 +417,7 @@ export class Backport {
       git fetch origin ${target}
       git worktree add -d .worktree/${branchname} origin/${target}
       cd .worktree/${branchname}
-      git checkout -b ${branchname}
+      git switch --create ${branchname}
       git cherry-pick -x ${commitShasToCherryPick.join(" ")}
       \`\`\``;
   }


### PR DESCRIPTION
This makes several small improvements to the local cherry-picking suggestions:
- No longer suggest `git merge-base` to determine the commits to cherry-pick
- No longer suggest a commit range for cherry-picking but rather be explicit about the commits
- Exclude any skipped merge commits from the commits to cherry-pick
- Use `git switch --create` rather than `git checkout --branch` as it may be easier to understand

Resolves #395 

> **Note**
> I'm making the assumption that all users of backport-action are at least on Git version 2.23 (16 Aug 2019). If anyone prefers the `git checkout --branch` command, please let me know, so I can prioritize #305 