### PR TITLE
Detect squash and rebase merge methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ Default: `false`
 
 When enabled, the action detects the method used to merge the pull request.
 - For "Squash and merge", the action cherry-picks the squashed commit.
-- For "Rebase and merge", the action cherry-picks the commits from the pull request.
+- For "Rebase and merge", the action cherry-picks the rebased commits.
 - For "Merged as a merge commit", the action cherry-picks the commits from the pull request.
 
 By default, the action always cherry-picks the commits from the pull request.

--- a/README.md
+++ b/README.md
@@ -135,6 +135,30 @@ Controls whether to copy the requested reviewers from the original pull request 
 Note that this does not request reviews from those users who already reviewed the original pull request.
 By default, the requested reviewers are not copied.
 
+### `experimental`
+
+Default:
+
+```json
+{
+  "detect_merge_method": false
+}
+```
+
+Configure experimental features by passing a JSON object.
+The following properties can be specified:
+
+#### `detect_merge_method`
+
+Default: `false`
+
+When enabled, the action detects the method used to merge the pull request.
+- For "Squash and merge", the action cherry-picks the squashed commit.
+- For "Rebase and merge", the action cherry-picks the commits from the pull request.
+- For "Merged as a merge commit", the action cherry-picks the commits from the pull request.
+
+By default, the action always cherry-picks the commits from the pull request.
+
 ### `github_token`
 
 Default: `${{ github.token }}`

--- a/action.yml
+++ b/action.yml
@@ -24,15 +24,23 @@ inputs:
       Note that this does not request reviews from those users who already reviewed the original pull request.
       By default, the requested reviewers are not copied.
     default: false
-  detect_merge_method:
+  experimental:
     description: >
-      Controls whether to detect the merge method used on the merged pull request.
-      When set to `true` the action will detect the merge method used on the merged pull request. The behavior of the action will depend on the merge method used.
-      For "Squash and merge", the action will cherry-pick the newly created commit.
-      For "Rebase and merge", the action will cherry-pick the commits from the pull request.
-      For "Create a merge commit", the action will cherry-pick the commits from the pull request.
-      When set to `false` the action will not detect the merge method used and always assume the merge method was `rebase`.
-    default: "false"
+      Configure experimental features by passing a JSON object.
+      The following properties can be specified:
+
+      #### `detect_merge_method`
+
+      When enabled, the action detects the method used to merge the pull request.
+      - For "Squash and merge", the action cherry-picks the squashed commit.
+      - For "Rebase and merge", the action cherry-picks the commits from the pull request.
+      - For "Merged as a merge commit", the action cherry-picks the commits from the pull request.
+
+      By default, the action always cherry-picks the commits from the pull request.
+    default: >
+      {
+        "detect_merge_method": false
+      }
   github_token:
     description: >
       Token to authenticate requests to GitHub.

--- a/action.yml
+++ b/action.yml
@@ -24,6 +24,15 @@ inputs:
       Note that this does not request reviews from those users who already reviewed the original pull request.
       By default, the requested reviewers are not copied.
     default: false
+  detect_merge_method:
+    description: >
+      Controls whether to detect the merge method used on the merged pull request.
+      When set to `true` the action will detect the merge method used on the merged pull request. The behavior of the action will depend on the merge method used.
+      For "Squash and merge", the action will cherry-pick the newly created commit.
+      For "Rebase and merge", the action will cherry-pick the commits from the pull request.
+      For "Create a merge commit", the action will cherry-pick the commits from the pull request.
+      When set to `false` the action will not detect the merge method used and always assume the merge method was `rebase`.
+    default: "false"
   github_token:
     description: >
       Token to authenticate requests to GitHub.
@@ -69,6 +78,7 @@ inputs:
       Note that the pull request's headref is excluded automatically.
       Can be used in addition to backport labels.
       By default, only backport labels are used to specify the target branches.
+
 outputs:
   was_successful:
     description: >

--- a/action.yml
+++ b/action.yml
@@ -33,7 +33,7 @@ inputs:
 
       When enabled, the action detects the method used to merge the pull request.
       - For "Squash and merge", the action cherry-picks the squashed commit.
-      - For "Rebase and merge", the action cherry-picks the commits from the pull request.
+      - For "Rebase and merge", the action cherry-picks the rebased commits.
       - For "Merged as a merge commit", the action cherry-picks the commits from the pull request.
 
       By default, the action always cherry-picks the commits from the pull request.

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -156,7 +156,7 @@ export class Backport {
 
       console.log("Checking the merged pull request for merge commits");
       const mergeCommitShas = await this.git.findMergeCommits(
-        commitShas,
+        commitShasToCherryPick,
         this.config.pwd,
       );
       console.log(
@@ -183,7 +183,7 @@ export class Backport {
         this.config.commits.merge_commits == "skip"
       ) {
         console.log("Skipping merge commits: " + mergeCommitShas);
-        const nonMergeCommitShas = commitShas.filter(
+        const nonMergeCommitShas = commitShasToCherryPick.filter(
           (sha) => !mergeCommitShas.includes(sha),
         );
         commitShasToCherryPick = nonMergeCommitShas;

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -107,8 +107,9 @@ export class Backport {
           case MergeStrategy.SQUASHED:
             // If merged via a squash merge_commit_sha represents the SHA of the squashed commit on
             // the base branch. We must fetch it and its parent in case of a shallowly cloned repo
+            // To store the fetched commits indefinitely we save them to a remote ref using the sha
             await this.git.fetch(
-              merge_commit_sha!,
+              `+${merge_commit_sha}:refs/remotes/origin/${merge_commit_sha}`,
               this.config.pwd,
               2, // +1 in case this concerns a shallowly cloned repo
             );
@@ -116,8 +117,10 @@ export class Backport {
             break;
           case MergeStrategy.REBASED:
             // If rebased merge_commit_sha represents the commit that the base branch was updated to
+            // We must fetch it, its parents, and one extra parent in case of a shallowly cloned repo
+            // To store the fetched commits indefinitely we save them to a remote ref using the sha
             await this.git.fetch(
-              merge_commit_sha!,
+              `+${merge_commit_sha}:refs/remotes/origin/${merge_commit_sha}`,
               this.config.pwd,
               mainpr.commits + 1, // +1 in case this concerns a shallowly cloned repo
             );

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -106,7 +106,12 @@ export class Backport {
         switch (await this.github.mergeStrategy(mainpr, merge_commit_sha)) {
           case MergeStrategy.SQUASHED:
             // If merged via a squash merge_commit_sha represents the SHA of the squashed commit on
-            // the base branch.
+            // the base branch. We must fetch it and its parent in case of a shallowly cloned repo
+            await this.git.fetch(
+              merge_commit_sha!,
+              this.config.pwd,
+              2, // +1 in case this concerns a shallowly cloned repo
+            );
             commitShasToCherryPick = [merge_commit_sha!];
             break;
           case MergeStrategy.REBASED:
@@ -205,7 +210,7 @@ export class Backport {
         console.log(`Backporting to target branch '${target}...'`);
 
         try {
-          await this.git.fetch(target, this.config.pwd, 2);
+          await this.git.fetch(target, this.config.pwd, 1);
         } catch (error) {
           if (error instanceof GitRefNotFoundError) {
             const message = this.composeMessageForFetchTargetFailure(error.ref);

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -100,12 +100,12 @@ export class Backport {
       let commitShasToCherryPick;
 
       if (this.config.experimental.detect_merge_method) {
+        const merge_commit_sha = await this.github.getMergeCommitSha(mainpr);
+
         // switch case to check if it is a squash, rebase, or merge commit
-        switch (await this.github.mergeStrategy(mainpr)) {
+        switch (await this.github.mergeStrategy(mainpr, merge_commit_sha)) {
           case MergeStrategy.SQUASHED:
-            commitShasToCherryPick = [
-              await this.github.getMergeCommitSha(mainpr),
-            ]?.filter(Boolean) as string[];
+            commitShasToCherryPick = [merge_commit_sha!];
             break;
           case MergeStrategy.REBASED:
             commitShasToCherryPick = commitShas;
@@ -126,6 +126,7 @@ export class Backport {
             commitShasToCherryPick = commitShas;
             break;
         }
+
       } else {
         console.log(
           "Not detecting merge strategy. Using commits from the Pull Request.",

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -32,8 +32,16 @@ export type Config = {
   copy_milestone: boolean;
   copy_assignees: boolean;
   copy_requested_reviewers: boolean;
+  experimental: Experimental;
+};
+
+type Experimental = {
   detect_merge_method: boolean;
 };
+const experimentalDefaults: Experimental = {
+  detect_merge_method: false,
+};
+export { experimentalDefaults };
 
 enum Output {
   wasSuccessful = "was_successful",
@@ -91,7 +99,7 @@ export class Backport {
 
       let commitShasToCherryPick;
 
-      if (this.config.detect_merge_method) {
+      if (this.config.experimental.detect_merge_method) {
         // switch case to check if it is a squash, rebase, or merge commit
         switch (await this.github.mergeStrategy(mainpr)) {
           case MergeStrategy.SQUASHED:

--- a/src/git.ts
+++ b/src/git.ts
@@ -66,7 +66,10 @@ export class Git {
         `'git log --pretty=format:"%H" ${range}' failed with exit code ${exitCode}`,
       );
     }
-    const commitShas = stdout.split("\n").filter((sha) => sha.trim() !== "");
+    const commitShas = stdout
+      .split("\n")
+      .map((sha) => sha.replace(/"/g, ""))
+      .filter((sha) => sha.trim() !== "");
     return commitShas;
   }
 

--- a/src/git.ts
+++ b/src/git.ts
@@ -52,6 +52,24 @@ export class Git {
     }
   }
 
+  public async findCommitsInRange(
+    range: string,
+    pwd: string,
+  ): Promise<string[]> {
+    const { exitCode, stdout } = await this.git(
+      "log",
+      ['--pretty=format:"%H"', range],
+      pwd,
+    );
+    if (exitCode !== 0) {
+      throw new Error(
+        `'git log --pretty=format:"%H" ${range}' failed with exit code ${exitCode}`,
+      );
+    }
+    const commitShas = stdout.split("\n").filter((sha) => sha.trim() !== "");
+    return commitShas;
+  }
+
   public async findMergeCommits(
     commitShas: string[],
     pwd: string,

--- a/src/git.ts
+++ b/src/git.ts
@@ -58,7 +58,7 @@ export class Git {
   ): Promise<string[]> {
     const { exitCode, stdout } = await this.git(
       "log",
-      ['--pretty=format:"%H"', range],
+      ['--pretty=format:"%H"', "--reverse", range],
       pwd,
     );
     if (exitCode !== 0) {

--- a/src/github.ts
+++ b/src/github.ts
@@ -221,21 +221,6 @@ export class Github implements GithubApi {
   }
 
   /**
-   * Retrieves the merge commit SHA and its parents for a given pull request.
-   * @param pull The pull request object.
-   * @returns An object containing the merge commit SHA and its parents, or null if the merge commit is not found.
-   */
-  public async getMergeCommitShaAndParents(pull: PullRequest) {
-    const merge_commit_sha = await this.getMergeCommitSha(pull);
-    if (!merge_commit_sha) {
-      console.log("likely not merged yet.");
-      return null;
-    }
-    const parents = await this.getParents(merge_commit_sha);
-    return { merge_commit_sha, parents };
-  }
-
-  /**
    * Checks if a commit is a merge commit.
    * @param parents - An array of parent commit hashes.
    * @returns A promise that resolves to a boolean indicating whether the commit is a merge commit.

--- a/src/github.ts
+++ b/src/github.ts
@@ -154,6 +154,15 @@ export class Github implements GithubApi {
 
   /**
    * Retrieves the SHA of the merge commit for a given pull request.
+   *
+   * After merging a pull request, the `merge_commit_sha` attribute changes depending on how you merged the pull request:
+   *
+   * - If merged as a merge commit, `merge_commit_sha` represents the SHA of the merge commit.
+   * - If merged via a squash, `merge_commit_sha` represents the SHA of the squashed commit on the base branch.
+   * - If rebased, `merge_commit_sha` represents the commit that the base branch was updated to.
+   *
+   * See: https://docs.github.com/en/free-pro-team@latest/rest/pulls/pulls?apiVersion=2022-11-28#get-a-pull-request
+   *
    * @param pull - The pull request object.
    * @returns The SHA of the merge commit.
    */

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,7 @@ async function run(): Promise<void> {
   const copy_assignees = core.getInput("copy_assignees");
   const copy_milestone = core.getInput("copy_milestone");
   const copy_requested_reviewers = core.getInput("copy_requested_reviewers");
+  const detect_merge_method = core.getInput("detect_merge_method");
 
   if (merge_commits != "fail" && merge_commits != "skip") {
     const message = `Expected input 'merge_commits' to be either 'fail' or 'skip', but was '${merge_commits}'`;
@@ -42,6 +43,7 @@ async function run(): Promise<void> {
     copy_assignees: copy_assignees === "true",
     copy_milestone: copy_milestone === "true",
     copy_requested_reviewers: copy_requested_reviewers === "true",
+    detect_merge_method: detect_merge_method === "true",
   };
   const backport = new Backport(github, config, git);
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -3,6 +3,7 @@ import { Backport, Config, experimentalDefaults } from "./backport";
 import { Github } from "./github";
 import { Git } from "./git";
 import { execa } from "execa";
+import dedent from "dedent";
 
 /**
  * Called from the action.yml.
@@ -28,6 +29,14 @@ async function run(): Promise<void> {
     console.error(message);
     core.setFailed(message);
     return;
+  }
+
+  for (const key in experimental) {
+    if (!(key in experimentalDefaults)) {
+      console.warn(dedent`Encountered unexpected key in input 'experimental'.\
+        No experimental config options known for key '${key}'.\
+        Please check the documentation for details about experimental features.`);
+    }
   }
 
   const github = new Github(token);

--- a/src/main.ts
+++ b/src/main.ts
@@ -1,5 +1,5 @@
 import * as core from "@actions/core";
-import { Backport, Config } from "./backport";
+import { Backport, Config, experimentalDefaults } from "./backport";
 import { Github } from "./github";
 import { Git } from "./git";
 import { execa } from "execa";
@@ -21,7 +21,7 @@ async function run(): Promise<void> {
   const copy_assignees = core.getInput("copy_assignees");
   const copy_milestone = core.getInput("copy_milestone");
   const copy_requested_reviewers = core.getInput("copy_requested_reviewers");
-  const detect_merge_method = core.getInput("detect_merge_method");
+  const experimental = JSON.parse(core.getInput("experimental"));
 
   if (merge_commits != "fail" && merge_commits != "skip") {
     const message = `Expected input 'merge_commits' to be either 'fail' or 'skip', but was '${merge_commits}'`;
@@ -43,7 +43,7 @@ async function run(): Promise<void> {
     copy_assignees: copy_assignees === "true",
     copy_milestone: copy_milestone === "true",
     copy_requested_reviewers: copy_requested_reviewers === "true",
-    detect_merge_method: detect_merge_method === "true",
+    experimental: { ...experimentalDefaults, ...experimental },
   };
   const backport = new Backport(github, config, git);
 


### PR DESCRIPTION
@korthout Github allows multiple merge methods. 

- "Rebase and Merge"


In cases where the merger used "Rebase and Merge" we can use the commits associated with the PR. (Not the commits that will be applied on the `head `branch once the PR is merged). 

- "Squash and Merge"

When using "Squash and Merge" we should use the single squashed commit that ends up on the `head` to accurately reflect any changes in the commit message and to ensure an accurate history between branches.


This patch tries to implement this behavior by looking at the parent of the `merge_commit_sha` that is populated when the PR is merged. If the parent is also associated to the PR (utilising `octokit.rest.repos.listPullRequestsAssociatedWithCommit` to check this) we can assume that the "rebase and merge" strategy was used as a squash would only produce a single commit and the parent would not be associated with the PR.
If the parent is not associated to the PR, we can use the newly generated `merge_commit_sha` which is the squashed commit applied on the `head`.
