### PR TITLE
fix: change condition to start a backport by comment

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -21,7 +21,7 @@ jobs:
       ) || (
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
-        contains(github.event.comment.body, '/backport')
+        startsWith(github.event.comment.body, '/backport')
       )
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # Only run when pull request is merged
-    # or when a comment containing `/backport` is created
+    # or when a comment starting with `/backport` is created
     if: >
       (
         github.event_name == 'pull_request' &&

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ jobs:
     runs-on: ubuntu-latest
 
     # Only run when pull request is merged
-    # or when a comment containing `/backport` is created by someone other than the
+    # or when a comment starting with `/backport` is created by someone other than the
     # https://github.com/backport-action bot user (user id: 97796249). Note that if you use your
     # own PAT as `github_token`, that you should replace this id with yours.
     if: >
@@ -90,7 +90,7 @@ jobs:
         github.event_name == 'issue_comment' &&
         github.event.issue.pull_request &&
         github.event.comment.user.id != 97796249 &&
-        contains(github.event.comment.body, '/backport')
+        startsWith(github.event.comment.body, '/backport')
       )
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
the `contains`  expression can lead to unexpected action boot-loops when the error itself contains `/backport`. 

This can be the case when a branch is includes the name "backport" like in this example comment 
```
example error message .. in branch origin/backport-form-xx-to-xx
```

Using `startsWith` to reduce the likeliness of this issue. https://docs.github.com/en/actions/learn-github-actions/expressions#startswith