### PR TITLE
fix: rendering templates due to missing brackets

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,7 +16,7 @@ export function replacePlaceholders(
     .replace("${pull_author}", main.user.login)
     .replace("${pull_number}", main.number.toString())
     .replace("${pull_title}", main.title)
-    .replace("${pull_description", main.body ?? "")
+    .replace("${pull_description}", main.body ?? "")
     .replace("${target_branch}", target)
     .replace("${issue_refs}", issues.join(" "));
 }


### PR DESCRIPTION
The `pull_description` placeholder was incorrectly specified as `${pull_description` (missing the closing bracket). 

When using `${pull_description}`, the `${pull_description` part would be replaced, and the `}` would stay untouched.