### PR TITLE
Suggest to fetch and checkout draft pr branch directly

### DIFF
--- a/src/backport.ts
+++ b/src/backport.ts
@@ -614,10 +614,9 @@ export class Backport {
     if (branchExist) {
       if (confictResolution === "draft_commit_conflicts") {
         return dedent`\`\`\`bash
-        git fetch origin ${target}
-        git worktree add -d .worktree/${branchname} origin/${target}
+        git fetch origin ${branchname}
+        git worktree add --checkout .worktree/${branchname} origin/${target}
         cd .worktree/${branchname}
-        git switch ${branchname}
         git reset --hard HEAD^
         git cherry-pick -x ${commitShasToCherryPick.join(" ")}
         git push --force-with-lease


### PR DESCRIPTION
When the pull request is created in draft mode because of conflicts, the suggestion did not fetch the branch of the opened draft pull request. This meant that the instructions fail when switching, and the commits are cherry-picked on the wrong branch.

Instead, we can fetch the branchname immediately. We no longer need to fetch target either. And while we're at it, we can also simply checkout the branch immediately, so we don't have to switch to it separately.

closes #421 