### PR TITLE
Checkout draft branch instead of target in suggestion

### DIFF
--- a/src/backport.ts
+++ b/src/backport.ts
@@ -615,7 +615,7 @@ export class Backport {
       if (confictResolution === "draft_commit_conflicts") {
         return dedent`\`\`\`bash
         git fetch origin ${branchname}
-        git worktree add --checkout .worktree/${branchname} origin/${target}
+        git worktree add --checkout .worktree/${branchname} ${branchname}
         cd .worktree/${branchname}
         git reset --hard HEAD^
         git cherry-pick -x ${commitShasToCherryPick.join(" ")}


### PR DESCRIPTION
When resolving the conflicts of a draft backport pull request, the instructions say to checkout the target branch in a new worktree. However, that doesn't make sense for the draft pull request, because we've already created a backport branch. We should checkout the backport branch (branchname) instead of target.

resolves #421 