### PR TITLE
Delimit `add_labels` using comma

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ By default, the original author is not made an assignee.
 
 Default: `''` (disabled)
 
-The action will add these labels (space-delimited) to the backport pull request.
+The action will add these labels (comma-delimited) to the backport pull request.
 By default, no labels are added.
 
 ### `branch_name`

--- a/action.yml
+++ b/action.yml
@@ -9,7 +9,7 @@ inputs:
       By default, the original author is not made an assignee.
   add_labels:
     description: >
-      The action will add these labels (space-delimited) to the backport pull request.
+      The action will add these labels (comma-delimited) to the backport pull request.
       By default, no labels are added.
   branch_name:
     description: >

--- a/src/main.ts
+++ b/src/main.ts
@@ -82,7 +82,7 @@ async function run(): Promise<void> {
     pull: { description, title, branch_name },
     copy_labels_pattern:
       copy_labels_pattern === "" ? undefined : new RegExp(copy_labels_pattern),
-    add_labels: add_labels === "" ? [] : add_labels.split(/[ ]/),
+    add_labels: add_labels === "" ? [] : add_labels.split(/[,]/),
     target_branches: target_branches === "" ? undefined : target_branches,
     commits: { cherry_picking, merge_commits },
     copy_assignees: copy_assignees === "true",


### PR DESCRIPTION
It should be possible to add labels that contain spaces. So we need to find another delimiter. GitHub does not seem to support labels that include commas, so we can use this instead.