### PR TITLE
Define dependency versions explicitly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "3.4.0-SNAPSHOT",
       "license": "MIT",
       "dependencies": {
-        "@actions/core": "^1.11.1",
-        "@actions/github": "^6.0.1",
-        "@types/dedent": "^0.7.2",
-        "dedent": "^1.6.0",
-        "execa": "^7.2.0"
+        "@actions/core": "1.11.1",
+        "@actions/github": "6.0.1",
+        "@types/dedent": "0.7.2",
+        "dedent": "1.7.0",
+        "execa": "7.2.0"
       },
       "devDependencies": {
         "@types/jest": "30.0.0",
@@ -22,6 +22,9 @@
         "prettier": "3.6.2",
         "ts-jest": "29.4.1",
         "typescript": "5.9.2"
+      },
+      "engines": {
+        "node": ">=24.0.0 <25"
       }
     },
     "node_modules/@actions/core": {

--- a/package.json
+++ b/package.json
@@ -27,11 +27,11 @@
     "node": ">=24.0.0 <25"
   },
   "dependencies": {
-    "@actions/core": "^1.11.1",
-    "@actions/github": "^6.0.1",
-    "@types/dedent": "^0.7.2",
-    "dedent": "^1.6.0",
-    "execa": "^7.2.0"
+    "@actions/core": "1.11.1",
+    "@actions/github": "6.0.1",
+    "@types/dedent": "0.7.2",
+    "dedent": "1.7.0",
+    "execa": "7.2.0"
   },
   "devDependencies": {
     "@types/jest": "30.0.0",


### PR DESCRIPTION
By being explicit about the version numbers, we are more clear about how we expect to build this project.

Note that here we were already using dedent 1.7.0 (in package-lock) but were defining it as ^1.6.0 in package.json.