### PR TITLE
fix(cherry-pick): stop reporting an empty cherry-pick as a conflict

### DIFF
--- a/README.md
+++ b/README.md
@@ -365,6 +365,17 @@ Note that this does not request reviews from those users who already reviewed th
 Use `copy_all_reviewers` instead to also request reviews from those users.
 By default, the requested reviewers are not copied.
 
+### `empty_commits`
+
+Default: `skip`
+
+Specifies how the action should deal with commits that are empty on the target branch, i.e. commits whose changes the target branch already contains. This is what a repeat backport run encounters after an earlier backport was merged.
+
+- When set to `skip` the action cherry-picks the remaining commits. When every commit is empty there is nothing to backport, so the action creates no pull request and reports the target branch as skipped.
+- When set to `fail` the backport fails when the action encounters an empty commit.
+
+Note that commits which were already empty in the original pull request are treated the same way.
+
 ### `experimental`
 
 Default:

--- a/action.yml
+++ b/action.yml
@@ -107,6 +107,13 @@ inputs:
       Use `copy_all_reviewers` instead to also request reviews from those users.
       By default, the requested reviewers are not copied.
     default: false
+  empty_commits:
+    description: >
+      Specifies how the action should deal with commits that are empty on the target branch,
+      i.e. commits whose changes the target branch already contains.
+      When set to `skip` the action cherry-picks the remaining commits, and creates no pull request when every commit is empty.
+      When set to `fail` the backport fails when the action encounters an empty commit.
+    default: skip
   experimental:
     description: >
       Configure experimental features by passing a JSON object.

--- a/src/backport.ts
+++ b/src/backport.ts
@@ -7,7 +7,7 @@ import {
   RequestError,
 } from "./github.js";
 import { GithubApi } from "./github.js";
-import { GitApi, GitRefNotFoundError } from "./git.js";
+import { CherryPickResult, GitApi, GitRefNotFoundError } from "./git.js";
 import {
   CommentContext,
   formatInitialComment,
@@ -18,6 +18,7 @@ import {
   CheckoutError,
   CherryPickError,
   CreatePRError,
+  EmptyCherryPickError,
   GitPushError,
   TargetResult,
 } from "./errors.js";
@@ -76,6 +77,7 @@ export type Config = {
   commits: {
     cherry_picking: "auto" | "pull_request_head";
     cherry_picking_merge_mode: "default" | "whitespace_tolerant";
+    empty_commits: "fail" | "skip";
     merge_commits: "fail" | "skip";
   };
   copy_milestone: boolean;
@@ -411,7 +413,7 @@ export class Backport {
         };
       }
 
-      let uncommittedShas: string[] | null;
+      let cherryPick: CherryPickResult;
 
       if (
         this.config.commits.cherry_picking_merge_mode === "whitespace_tolerant"
@@ -420,13 +422,17 @@ export class Backport {
       }
 
       try {
-        uncommittedShas = await this.git.cherryPick(
+        cherryPick = await this.git.cherryPick(
           commitShasToCherryPick,
           this.config.experimental.conflict_resolution,
           this.config.pwd,
           this.config.commits.cherry_picking_merge_mode,
+          this.config.commits.empty_commits,
         );
       } catch (error) {
+        if (error instanceof EmptyCherryPickError) {
+          return { status: "failed", targetBranch, branchname, error };
+        }
         const message =
           error instanceof Error
             ? error.message
@@ -440,6 +446,17 @@ export class Backport {
             branchname,
             commitShasToCherryPick,
           ),
+        };
+      }
+
+      if (cherryPick.status === "empty") {
+        console.log(
+          `Nothing to backport to ${targetBranch}, it already contains these changes`,
+        );
+        return {
+          status: "skipped",
+          targetBranch,
+          reason: "target branch already contains these changes",
         };
       }
 
@@ -481,7 +498,7 @@ export class Backport {
           head: branchname,
           base: targetBranch,
           maintainer_can_modify: true,
-          draft: uncommittedShas !== null,
+          draft: cherryPick.status === "conflicts",
         });
       } catch (error) {
         if (!(error instanceof RequestError)) throw error;
@@ -524,13 +541,13 @@ export class Backport {
         { owner: context.workflowOwner, repo: context.workflowRepo },
       );
 
-      if (uncommittedShas !== null) {
+      if (cherryPick.status === "conflicts") {
         return {
           status: "success_with_conflicts",
           targetBranch,
           newPrNumber: new_pr.number,
           branchname,
-          uncommittedShas,
+          uncommittedShas: cherryPick.uncommittedShas,
         };
       }
       return {

--- a/src/comments.ts
+++ b/src/comments.ts
@@ -4,6 +4,7 @@ import {
   CheckoutError,
   CherryPickError,
   CreatePRError,
+  EmptyCherryPickError,
   GitPushError,
   TargetResult,
 } from "./errors.js";
@@ -169,6 +170,15 @@ export function formatSingleTargetComment(
              git switch --create ${error.branch}
              git cherry-pick -x ${error.commits.join(" ")}
              \`\`\``,
+    );
+  }
+
+  if (error instanceof EmptyCherryPickError) {
+    return wrapDetails(
+      `:x: ${targetBranch} — changes already present`,
+      dedent`Tried to cherry-pick commits onto \`${targetBranch}\`, but it already contains their changes, so the cherry-pick was empty.
+
+             Set \`empty_commits: skip\` to skip such commits instead.`,
     );
   }
 

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -36,6 +36,16 @@ export class CherryPickError extends BackportError {
   }
 }
 
+export class EmptyCherryPickError extends BackportError {
+  commits: string[];
+
+  constructor(message: string, commits: string[]) {
+    super(message);
+    this.name = "EmptyCherryPickError";
+    this.commits = commits;
+  }
+}
+
 export class GitPushError extends BackportError {
   branch: string;
   remote: string;

--- a/src/git.ts
+++ b/src/git.ts
@@ -1,6 +1,6 @@
 import { ExecOptions, getExecOutput } from "@actions/exec";
 
-import { BackportError, GitPushError } from "./errors.js";
+import { BackportError, EmptyCherryPickError, GitPushError } from "./errors.js";
 
 export class GitRefNotFoundError extends BackportError {
   ref: string;
@@ -10,6 +10,17 @@ export class GitRefNotFoundError extends BackportError {
     this.ref = ref;
   }
 }
+
+/**
+ * Outcome of cherry-picking the commits of a pull request onto a target branch.
+ *
+ * `empty` means every commit was already present on the target branch, so the
+ * branch holds nothing to open a pull request for.
+ */
+export type CherryPickResult =
+  | { status: "picked" }
+  | { status: "conflicts"; uncommittedShas: string[] }
+  | { status: "empty" };
 
 export interface GitApi {
   fetch(
@@ -33,7 +44,8 @@ export interface GitApi {
     conflictResolution: string,
     pwd: string,
     mergeMode: "default" | "whitespace_tolerant",
-  ): Promise<string[] | null>;
+    emptyCommits: "fail" | "skip",
+  ): Promise<CherryPickResult>;
 }
 
 export class Git implements GitApi {
@@ -183,12 +195,29 @@ export class Git implements GitApi {
     }
   }
 
+  /**
+   * Reports whether the halted cherry-pick applied nothing, i.e. the target
+   * branch already contains the changes of the commit.
+   *
+   * Only valid on exit code 1. A cherry-pick that refuses to start exits 128
+   * instead, so on exit code 1 the index holds nothing but this cherry-pick.
+   */
+  private async isEmptyPick(pwd: string): Promise<boolean> {
+    const { exitCode } = await this.git(
+      "diff",
+      ["--cached", "--quiet", "HEAD"],
+      pwd,
+    );
+    return exitCode === 0;
+  }
+
   public async cherryPick(
     commitShas: string[],
     conflictResolution: string,
     pwd: string,
     mergeMode: "default" | "whitespace_tolerant",
-  ): Promise<string[] | null> {
+    emptyCommits: "fail" | "skip",
+  ): Promise<CherryPickResult> {
     const strategyArgs =
       mergeMode === "whitespace_tolerant" ? ["-Xignore-space-at-eol"] : [];
 
@@ -202,18 +231,52 @@ export class Git implements GitApi {
       );
     };
 
+    const abortEmptyCherryPickAndThrow = async (commitShas: string[]) => {
+      await this.git("cherry-pick", ["--abort"], pwd);
+      throw new EmptyCherryPickError(
+        `'git cherry-pick -x ${commitShas}' is empty, because the target branch already contains these changes`,
+        commitShas,
+      );
+    };
+
+    const haltedSha = async () => {
+      const { stdout } = await this.git("rev-parse", ["CHERRY_PICK_HEAD"], pwd);
+      return stdout.trim();
+    };
+
+    let emptyShas: string[] = [];
+    const everyCommitWasEmpty = () =>
+      emptyShas.length > 0 && emptyShas.length === commitShas.length;
+
     if (conflictResolution === `fail`) {
-      const { exitCode } = await this.git(
+      let { exitCode } = await this.git(
         "cherry-pick",
         ["-x", ...strategyArgs, ...commitShas],
         pwd,
       );
 
+      // `--skip` resumes the sequence, which halts again on the next empty
+      // commit or conflict, so this drains any number of empty commits.
+      while (exitCode === 1 && (await this.isEmptyPick(pwd))) {
+        if (emptyCommits === `fail`) {
+          await abortEmptyCherryPickAndThrow(commitShas);
+        }
+        const sha = await haltedSha();
+        console.log(`Skipping ${sha}, the target branch already contains it`);
+        emptyShas.push(sha);
+        ({ exitCode } = await this.git("cherry-pick", ["--skip"], pwd));
+      }
+
       if (exitCode !== 0) {
         await abortCherryPickAndThrow(commitShas, exitCode);
       }
 
-      return null;
+      // No cherry-pick is in progress here, so this must not abort one.
+      if (everyCommitWasEmpty()) {
+        return { status: "empty" };
+      }
+
+      return { status: "picked" };
     } else {
       let uncommittedShas: string[] = [...commitShas];
 
@@ -227,6 +290,34 @@ export class Git implements GitApi {
 
         if (exitCode !== 0) {
           if (exitCode === 1) {
+            if (await this.isEmptyPick(pwd)) {
+              if (emptyCommits === `fail`) {
+                await abortEmptyCherryPickAndThrow([uncommittedShas[0]]);
+              }
+
+              console.log(
+                `Skipping ${uncommittedShas[0]}, the target branch already contains it`,
+              );
+              emptyShas.push(uncommittedShas[0]);
+
+              // Clears the sequencer state, which would block the next commit.
+              const { exitCode: skipExitCode } = await this.git(
+                "cherry-pick",
+                ["--skip"],
+                pwd,
+              );
+
+              if (skipExitCode !== 0) {
+                await abortCherryPickAndThrow(
+                  [uncommittedShas[0]],
+                  skipExitCode,
+                );
+              }
+
+              uncommittedShas.shift();
+              continue;
+            }
+
             // conflict encountered
             if (conflictResolution === `draft_commit_conflicts`) {
               // Commit the conflict, resolution of this commit is left to the user.
@@ -241,7 +332,7 @@ export class Git implements GitApi {
                 await abortCherryPickAndThrow(commitShas, exitCode);
               }
 
-              return uncommittedShas;
+              return { status: "conflicts", uncommittedShas };
             } else {
               throw new Error(
                 `'Unsupported conflict_resolution method ${conflictResolution}`,
@@ -257,7 +348,11 @@ export class Git implements GitApi {
         uncommittedShas.shift();
       }
 
-      return null;
+      if (everyCommitWasEmpty()) {
+        return { status: "empty" };
+      }
+
+      return { status: "picked" };
     }
   }
 }

--- a/src/legacy-comments.ts
+++ b/src/legacy-comments.ts
@@ -4,6 +4,7 @@ import {
   CheckoutError,
   CherryPickError,
   CreatePRError,
+  EmptyCherryPickError,
   GitPushError,
   TargetResult,
 } from "./errors.js";
@@ -22,6 +23,9 @@ export function composeFailureMessage(
       error.branch,
       error.commits,
     );
+  }
+  if (error instanceof EmptyCherryPickError) {
+    return composeMessageForEmptyCherryPick(targetBranch);
   }
   if (error instanceof CherryPickError) {
     return composeMessageForCherryPickFailure(
@@ -131,6 +135,12 @@ function composeMessageForCherryPickFailure(
 
                 Please cherry-pick the changes locally and resolve any conflicts.
                 ${suggestion}`;
+}
+
+function composeMessageForEmptyCherryPick(target: string): string {
+  return dedent`Backport failed for \`${target}\`, because \`${target}\` already contains the changes of the commit(s) to backport.
+
+                Set \`empty_commits: skip\` to skip such commits instead.`;
 }
 
 function composeMessageForGitPushFailure(

--- a/src/main.ts
+++ b/src/main.ts
@@ -29,6 +29,7 @@ async function run(): Promise<void> {
   const target_branches = core.getInput("target_branches");
   const cherry_picking = core.getInput("cherry_picking");
   const cherry_picking_merge_mode = core.getInput("cherry_picking_merge_mode");
+  const empty_commits = core.getInput("empty_commits");
   const merge_commits = core.getInput("merge_commits");
   const copy_assignees = core.getInput("copy_assignees");
   const copy_milestone = core.getInput("copy_milestone");
@@ -56,6 +57,13 @@ async function run(): Promise<void> {
   );
   if (coercedCherryPickingMergeMode === "invalid") {
     const message = `Invalid value for \`cherry_picking_merge_mode\`: \`${cherry_picking_merge_mode}\`. Accepted values: \`default\`, \`whitespace_tolerant\`.`;
+    console.error(message);
+    core.setFailed(message);
+    return;
+  }
+
+  if (empty_commits != "fail" && empty_commits != "skip") {
+    const message = `Expected input 'empty_commits' to be either 'fail' or 'skip', but was '${empty_commits}'`;
     console.error(message);
     core.setFailed(message);
     return;
@@ -135,6 +143,7 @@ async function run(): Promise<void> {
     commits: {
       cherry_picking,
       cherry_picking_merge_mode: coercedCherryPickingMergeMode,
+      empty_commits,
       merge_commits,
     },
     copy_assignees: copy_assignees === "true",

--- a/src/test/backport.integration.test.ts
+++ b/src/test/backport.integration.test.ts
@@ -32,7 +32,7 @@
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { Backport } from "../backport.js";
-import { GitPushError } from "../errors.js";
+import { EmptyCherryPickError, GitPushError } from "../errors.js";
 import { GitRefNotFoundError } from "../git.js";
 import { MergeStrategy } from "../github.js";
 import { FakeGithub, requestError } from "./helpers/fake-github.js";
@@ -128,7 +128,7 @@ describe("Backport.run() orchestration", () => {
       const git = createMockGit({
         cherryPick: vi.fn().mockImplementation(async () => {
           cherryPickCallCount++;
-          if (cherryPickCallCount === 1) return null;
+          if (cherryPickCallCount === 1) return { status: "picked" };
           throw new Error("cherry-pick failed");
         }),
       });
@@ -225,6 +225,7 @@ describe("Backport.run() orchestration", () => {
         commits: {
           cherry_picking: "pull_request_head",
           cherry_picking_merge_mode: "default",
+          empty_commits: "skip",
           merge_commits: "fail",
         },
       });
@@ -237,7 +238,57 @@ describe("Backport.run() orchestration", () => {
         expect.anything(),
         expect.anything(),
         "default",
+        expect.anything(),
       );
+    });
+
+    it("every commit already on the target (skip mode): no PR, no comment, still successful", async () => {
+      const github = new FakeGithub();
+      const git = createMockGit({
+        cherryPick: vi.fn().mockResolvedValue({ status: "empty" }),
+      });
+      const config = makeConfig();
+      const backport = new Backport(github, config, git);
+      await backport.run();
+
+      expect(github.createdPRs).toHaveLength(0);
+      expect(github.comments).toHaveLength(0);
+      expect(core.setOutput).toHaveBeenCalledWith("was_successful", true);
+      expect(core.setOutput).toHaveBeenCalledWith("created_pull_numbers", "");
+    });
+
+    it("empty commit (fail mode): posts a comment naming the real reason", async () => {
+      const github = new FakeGithub();
+      const git = createMockGit({
+        cherryPick: vi
+          .fn()
+          .mockRejectedValue(
+            new EmptyCherryPickError("cherry-pick is empty", ["abc123"]),
+          ),
+      });
+      const config = makeConfig({
+        commits: {
+          cherry_picking: "auto",
+          cherry_picking_merge_mode: "default",
+          empty_commits: "fail",
+          merge_commits: "fail",
+        },
+      });
+      const backport = new Backport(github, config, git);
+      await backport.run();
+
+      expect(github.createdPRs).toHaveLength(0);
+      expect(github.comments).toContainEqual(
+        expect.objectContaining({
+          body: expect.stringContaining("already contains the changes"),
+        }),
+      );
+      expect(github.comments).not.toContainEqual(
+        expect.objectContaining({
+          body: expect.stringContaining("unable to cherry-pick"),
+        }),
+      );
+      expect(core.setOutput).toHaveBeenCalledWith("was_successful", false);
     });
 
     it("cherry-pick fails: posts failure comment with manual instructions", async () => {
@@ -260,7 +311,10 @@ describe("Backport.run() orchestration", () => {
     it("cherry-pick with conflicts (draft mode): creates draft PR, posts conflict comment", async () => {
       const github = new FakeGithub();
       const git = createMockGit({
-        cherryPick: vi.fn().mockResolvedValue(["abc123"]),
+        cherryPick: vi.fn().mockResolvedValue({
+          status: "conflicts",
+          uncommittedShas: ["abc123"],
+        }),
       });
       const config = makeConfig({
         experimental: { conflict_resolution: "draft_commit_conflicts" },
@@ -683,6 +737,21 @@ describe("Backport.run() orchestration", () => {
   });
 
   describe("comment_style: summary", () => {
+    it("empty cherry-pick: the summary table marks the target as skipped", async () => {
+      const github = new FakeGithub();
+      const git = createMockGit({
+        cherryPick: vi.fn().mockResolvedValue({ status: "empty" }),
+      });
+      const config = makeConfig({ comment_style: "summary" });
+      const backport = new Backport(github, config, git);
+      await backport.run();
+
+      expect(github.createdPRs).toHaveLength(0);
+      const final = github.updatedComments[github.updatedComments.length - 1];
+      expect(final.body).toContain(":heavy_minus_sign: Skipped");
+      expect(final.body).toContain("already contains these changes");
+    });
+
     it("creates a single comment up front and updates it after each target", async () => {
       const github = new FakeGithub({
         sourcePr: {
@@ -848,7 +917,10 @@ describe("Backport.run() orchestration", () => {
       const github = new FakeGithub();
       const git = createMockGit({
         // non-null array signals which SHAs still need to be cherry-picked as there were conflicts encountered
-        cherryPick: vi.fn().mockResolvedValue(["abc123"]),
+        cherryPick: vi.fn().mockResolvedValue({
+          status: "conflicts",
+          uncommittedShas: ["abc123"],
+        }),
       });
       const config = makeConfig({
         comment_style: "summary",
@@ -882,7 +954,10 @@ describe("Backport.run() orchestration", () => {
       github.failOn("createComment", new Error("create failed"));
       const git = createMockGit({
         // non-null array signals which SHAs still need to be cherry-picked as there were conflicts encountered
-        cherryPick: vi.fn().mockResolvedValue(["abc123"]),
+        cherryPick: vi.fn().mockResolvedValue({
+          status: "conflicts",
+          uncommittedShas: ["abc123"],
+        }),
       });
       const config = makeConfig({
         comment_style: "summary",

--- a/src/test/comments.test.ts
+++ b/src/test/comments.test.ts
@@ -11,6 +11,7 @@ import {
   CheckoutError,
   CherryPickError,
   CreatePRError,
+  EmptyCherryPickError,
   GitPushError,
   TargetResult,
 } from "../errors.js";
@@ -63,6 +64,20 @@ describe("formatSingleTargetComment", () => {
     expect(out).toContain("stable/8.0");
     expect(out).toContain("backport-42-to-8.0");
     expect(out).toContain("abc def");
+  });
+
+  it("EmptyCherryPickError: says the target already has the changes", () => {
+    const out = formatSingleTargetComment(
+      failed(
+        "stable/8.0",
+        new EmptyCherryPickError("cherry-pick is empty", ["abc"]),
+      ),
+      context,
+    );
+
+    expect(out).toContain("already contains their changes");
+    expect(out).toContain("stable/8.0");
+    expect(out).not.toContain("resolve any conflicts");
   });
 
   it("GitPushError: includes branch, remote, and exit code with PAT recovery", () => {

--- a/src/test/git.integration.test.ts
+++ b/src/test/git.integration.test.ts
@@ -46,6 +46,7 @@ import { FakeGithub } from "./helpers/fake-github.js";
 import { makeConfig } from "./helpers/config.js";
 import {
   createRepoTemplate,
+  addAlreadyBackportedCommit,
   addCommit,
   addConflictingCommits,
   createBranch,
@@ -197,6 +198,217 @@ describe("Backport.run() with real git", () => {
       ctx.expect(commits).toHaveLength(1);
       const content = await gitCmd(`show ${commits[0]}`, repo.workDir);
       ctx.expect(content).toContain("BACKPORT-CONFLICT");
+    },
+  );
+
+  it.concurrent(
+    "already backported: no PR, no failure comment",
+    async (ctx) => {
+      const repo = (ctx.repo = await template.createTestRepo());
+      const git = setupGit();
+
+      await createBranch(repo.workDir, "release", repo.initialCommitSha);
+
+      const featureSha = await addAlreadyBackportedCommit(
+        repo.workDir,
+        "release",
+        "README.md",
+      );
+      await createPullRequestRef(repo.workDir, 42, featureSha);
+
+      const github = new FakeGithub({
+        sourcePr: {
+          labels: [{ name: "backport release" }],
+          commitShas: [featureSha],
+          mergeCommitSha: featureSha,
+        },
+      });
+
+      const config = makeConfig({ pwd: repo.workDir });
+      const backport = new Backport(github, config, git);
+      await backport.run();
+
+      ctx.expect(github.createdPRs).toHaveLength(0);
+      ctx.expect(github.comments).toHaveLength(0);
+    },
+  );
+
+  it.concurrent(
+    "already backported (draft mode): no draft PR, no conflict commit",
+    async (ctx) => {
+      const repo = (ctx.repo = await template.createTestRepo());
+      const git = setupGit();
+
+      await createBranch(repo.workDir, "release", repo.initialCommitSha);
+
+      const featureSha = await addAlreadyBackportedCommit(
+        repo.workDir,
+        "release",
+        "README.md",
+      );
+      await createPullRequestRef(repo.workDir, 42, featureSha);
+
+      const github = new FakeGithub({
+        sourcePr: {
+          labels: [{ name: "backport release" }],
+          commitShas: [featureSha],
+          mergeCommitSha: featureSha,
+        },
+      });
+
+      const config = makeConfig({
+        pwd: repo.workDir,
+        experimental: { conflict_resolution: "draft_commit_conflicts" },
+      });
+      const backport = new Backport(github, config, git);
+      await backport.run();
+
+      ctx.expect(github.createdPRs).toHaveLength(0);
+      ctx.expect(github.comments).toHaveLength(0);
+      const commits = await git.findCommitsInRange(
+        "release..backport-42-to-release",
+        repo.workDir,
+      );
+      ctx.expect(commits).toHaveLength(0);
+    },
+  );
+
+  it.concurrent(
+    "already backported (empty_commits: fail): posts a comment naming the real reason",
+    async (ctx) => {
+      const repo = (ctx.repo = await template.createTestRepo());
+      const git = setupGit();
+
+      await createBranch(repo.workDir, "release", repo.initialCommitSha);
+
+      const featureSha = await addAlreadyBackportedCommit(
+        repo.workDir,
+        "release",
+        "README.md",
+      );
+      await createPullRequestRef(repo.workDir, 42, featureSha);
+
+      const github = new FakeGithub({
+        sourcePr: {
+          labels: [{ name: "backport release" }],
+          commitShas: [featureSha],
+          mergeCommitSha: featureSha,
+        },
+      });
+
+      const config = makeConfig({
+        pwd: repo.workDir,
+        commits: {
+          cherry_picking: "auto",
+          cherry_picking_merge_mode: "default",
+          empty_commits: "fail",
+          merge_commits: "fail",
+        },
+      });
+      const backport = new Backport(github, config, git);
+      await backport.run();
+
+      ctx.expect(github.createdPRs).toHaveLength(0);
+      ctx.expect(github.comments).toContainEqual(
+        ctx.expect.objectContaining({
+          body: ctx.expect.stringContaining("already contains the changes"),
+        }),
+      );
+      ctx.expect(github.comments).not.toContainEqual(
+        ctx.expect.objectContaining({
+          body: ctx.expect.stringContaining("unable to cherry-pick"),
+        }),
+      );
+    },
+  );
+
+  it.concurrent(
+    "partially backported: cherry-picks only the commits missing from the target",
+    async (ctx) => {
+      const repo = (ctx.repo = await template.createTestRepo());
+      const git = setupGit();
+
+      await createBranch(repo.workDir, "release", repo.initialCommitSha);
+
+      const backportedSha = await addAlreadyBackportedCommit(
+        repo.workDir,
+        "release",
+        "already-there.md",
+      );
+      const newSha = await addCommit(
+        repo.workDir,
+        "new.md",
+        "brand new content",
+        "Add new.md",
+      );
+      await pushBranch(repo.workDir);
+      await createPullRequestRef(repo.workDir, 42, newSha);
+
+      const github = new FakeGithub({
+        sourcePr: {
+          labels: [{ name: "backport release" }],
+          commitShas: [backportedSha, newSha],
+          mergeCommitSha: newSha,
+        },
+        mergeStrategyResult: MergeStrategy.MERGECOMMIT,
+        nextPrNumber: 999,
+      });
+
+      const config = makeConfig({ pwd: repo.workDir });
+      const backport = new Backport(github, config, git);
+      await backport.run();
+
+      ctx.expect(github.createdPRs).toHaveLength(1);
+      ctx.expect(github.createdPRs[0]).toMatchObject({ draft: false });
+      await expectCherryPickedCommits(
+        ctx,
+        git,
+        repo.workDir,
+        "release..backport-42-to-release",
+        [{ message: "Add new.md", cherryPickedFrom: newSha }],
+      );
+    },
+  );
+
+  it.concurrent(
+    "already backported commit followed by a conflicting one: reports the conflict",
+    async (ctx) => {
+      const repo = (ctx.repo = await template.createTestRepo());
+      const git = setupGit();
+
+      await createBranch(repo.workDir, "release", repo.initialCommitSha);
+
+      const backportedSha = await addAlreadyBackportedCommit(
+        repo.workDir,
+        "release",
+        "already-there.md",
+      );
+      const conflictingSha = await addConflictingCommits(
+        repo.workDir,
+        "release",
+        "shared.md",
+      );
+      await createPullRequestRef(repo.workDir, 42, conflictingSha);
+
+      const github = new FakeGithub({
+        sourcePr: {
+          labels: [{ name: "backport release" }],
+          commitShas: [backportedSha, conflictingSha],
+          mergeCommitSha: conflictingSha,
+        },
+        mergeStrategyResult: MergeStrategy.MERGECOMMIT,
+      });
+
+      const config = makeConfig({ pwd: repo.workDir });
+      const backport = new Backport(github, config, git);
+      await backport.run();
+
+      ctx.expect(github.createdPRs).toHaveLength(0);
+      ctx.expect(github.comments).toContainEqual(
+        ctx.expect.objectContaining({
+          body: ctx.expect.stringContaining("unable to cherry-pick"),
+        }),
+      );
     },
   );
 
@@ -437,7 +649,12 @@ describe("Backport.run() with real git", () => {
 
       const config = makeConfig({
         pwd: repo.workDir,
-        commits: { cherry_picking: "auto", merge_commits: "skip" },
+        commits: {
+          cherry_picking: "auto",
+          cherry_picking_merge_mode: "default",
+          empty_commits: "skip",
+          merge_commits: "skip",
+        },
       });
       const backport = new Backport(github, config, git);
       await backport.run();

--- a/src/test/git.test.ts
+++ b/src/test/git.test.ts
@@ -2,6 +2,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 
 let response = { exitCode: 0, stdout: "" };
 let responseCommit = { exitCode: 0, stdout: "" };
+// Exit code 1 means the index differs from HEAD, i.e. the cherry-pick hit a
+// conflict rather than turning out empty.
+let responseDiff = { exitCode: 1, stdout: "" };
+let responseSkip = { exitCode: 0, stdout: "" };
 
 const getExecOutputMock = vi.fn(
   (command: string, args?: readonly string[] | undefined) => {
@@ -10,6 +14,15 @@ const getExecOutputMock = vi.fn(
       if (subCommand === "commit") {
         // Mock behavior for "git commit"
         return responseCommit;
+      }
+      if (subCommand === "diff") {
+        return responseDiff;
+      }
+      if (subCommand === "cherry-pick" && args[1] === "--skip") {
+        return responseSkip;
+      }
+      if (subCommand === "rev-parse") {
+        return { exitCode: 0, stdout: "halted-sha\n" };
       }
     }
     return response;
@@ -21,6 +34,7 @@ vi.mock("@actions/exec", () => ({
 }));
 
 const { Git, GitRefNotFoundError } = await import("../git.js");
+const { EmptyCherryPickError } = await import("../errors.js");
 
 const git = new Git(
   "github-actions[bot]",
@@ -55,12 +69,17 @@ describe("git.fetch", () => {
 });
 
 describe("git.cherryPick", () => {
+  beforeEach(() => {
+    responseDiff = { exitCode: 1, stdout: "" };
+    responseSkip = { exitCode: 0, stdout: "" };
+  });
+
   describe("with conflict_resolution to fail", () => {
     describe("throws Error", () => {
       it("when failing with an unexpected non-zero exit code", async () => {
         response.exitCode = 1;
         await expect(
-          git.cherryPick(["unknown"], `fail`, "", "default"),
+          git.cherryPick(["unknown"], `fail`, "", "default", `skip`),
         ).rejects.toThrow(
           `'git cherry-pick -x unknown' failed with exit code 1`,
         );
@@ -71,8 +90,14 @@ describe("git.cherryPick", () => {
       it("when success", async () => {
         response.exitCode = 0;
         await expect(
-          git.cherryPick(["unknown"], `draft_commit_conflicts`, "", "default"),
-        ).resolves.toBe(null);
+          git.cherryPick(
+            ["unknown"],
+            `draft_commit_conflicts`,
+            "",
+            "default",
+            `skip`,
+          ),
+        ).resolves.toEqual({ status: "picked" });
       });
     });
   });
@@ -82,7 +107,13 @@ describe("git.cherryPick", () => {
       it("when failing with an unexpected non-zero and non-one exit code", async () => {
         response.exitCode = 128;
         await expect(
-          git.cherryPick(["unknown"], `draft_commit_conflicts`, "", "default"),
+          git.cherryPick(
+            ["unknown"],
+            `draft_commit_conflicts`,
+            "",
+            "default",
+            `skip`,
+          ),
         ).rejects.toThrow(
           `'git cherry-pick -x unknown' failed with exit code 128`,
         );
@@ -92,7 +123,13 @@ describe("git.cherryPick", () => {
         response.exitCode = 1;
         responseCommit.exitCode = 1;
         await expect(
-          git.cherryPick(["unknown"], `draft_commit_conflicts`, "", "default"),
+          git.cherryPick(
+            ["unknown"],
+            `draft_commit_conflicts`,
+            "",
+            "default",
+            `skip`,
+          ),
         ).rejects.toThrow(
           `'git cherry-pick -x unknown' failed with exit code 1`,
         );
@@ -108,8 +145,12 @@ describe("git.cherryPick", () => {
               `draft_commit_conflicts`,
               "",
               "default",
+              `skip`,
             ),
-          ).resolves.toEqual(["unknown"]);
+          ).resolves.toEqual({
+            status: "conflicts",
+            uncommittedShas: ["unknown"],
+          });
         });
       });
 
@@ -122,10 +163,67 @@ describe("git.cherryPick", () => {
               `draft_commit_conflicts`,
               "",
               "default",
+              `skip`,
             ),
-          ).resolves.toBe(null);
+          ).resolves.toEqual({ status: "picked" });
         });
       });
+    });
+  });
+});
+
+describe("git.cherryPick empty commits", () => {
+  beforeEach(() => {
+    response.exitCode = 1;
+    responseCommit.exitCode = 0;
+    // An index equal to HEAD: the cherry-pick applied nothing.
+    responseDiff = { exitCode: 0, stdout: "" };
+    responseSkip = { exitCode: 0, stdout: "" };
+    getExecOutputMock.mockClear();
+  });
+
+  describe("with empty_commits to skip", () => {
+    it("returns empty when every commit is already on the target branch", async () => {
+      await expect(
+        git.cherryPick(["unknown"], `fail`, "", "default", `skip`),
+      ).resolves.toEqual({ status: "empty" });
+    });
+
+    it("returns empty in draft mode without committing a conflict", async () => {
+      await expect(
+        git.cherryPick(
+          ["unknown"],
+          `draft_commit_conflicts`,
+          "",
+          "default",
+          `skip`,
+        ),
+      ).resolves.toEqual({ status: "empty" });
+      expect(
+        getExecOutputMock.mock.calls.some(
+          ([, args]) => Array.isArray(args) && args[0] === "commit",
+        ),
+      ).toBe(false);
+    });
+  });
+
+  describe("with empty_commits to fail", () => {
+    it("throws EmptyCherryPickError", async () => {
+      await expect(
+        git.cherryPick(["unknown"], `fail`, "", "default", `fail`),
+      ).rejects.toBeInstanceOf(EmptyCherryPickError);
+    });
+
+    it("throws EmptyCherryPickError in draft mode", async () => {
+      await expect(
+        git.cherryPick(
+          ["unknown"],
+          `draft_commit_conflicts`,
+          "",
+          "default",
+          `fail`,
+        ),
+      ).rejects.toBeInstanceOf(EmptyCherryPickError);
     });
   });
 });
@@ -139,7 +237,7 @@ describe("git.cherryPick mergeMode arg contract", () => {
 
   describe("fail mode (conflict_resolution: fail)", () => {
     it("default mode passes no extra flags", async () => {
-      await git.cherryPick(["abc123"], "fail", "", "default");
+      await git.cherryPick(["abc123"], "fail", "", "default", "skip");
       const cherryPickCall = getExecOutputMock.mock.calls.find(
         ([, args]) => Array.isArray(args) && args[0] === "cherry-pick",
       );
@@ -148,7 +246,13 @@ describe("git.cherryPick mergeMode arg contract", () => {
     });
 
     it("whitespace_tolerant mode adds -Xignore-space-at-eol", async () => {
-      await git.cherryPick(["abc123"], "fail", "", "whitespace_tolerant");
+      await git.cherryPick(
+        ["abc123"],
+        "fail",
+        "",
+        "whitespace_tolerant",
+        "skip",
+      );
       const cherryPickCall = getExecOutputMock.mock.calls.find(
         ([, args]) => Array.isArray(args) && args[0] === "cherry-pick",
       );
@@ -164,7 +268,13 @@ describe("git.cherryPick mergeMode arg contract", () => {
 
   describe("draft mode (conflict_resolution: draft_commit_conflicts)", () => {
     it("default mode passes no extra flags", async () => {
-      await git.cherryPick(["abc123"], "draft_commit_conflicts", "", "default");
+      await git.cherryPick(
+        ["abc123"],
+        "draft_commit_conflicts",
+        "",
+        "default",
+        "skip",
+      );
       const cherryPickCall = getExecOutputMock.mock.calls.find(
         ([, args]) => Array.isArray(args) && args[0] === "cherry-pick",
       );
@@ -178,6 +288,7 @@ describe("git.cherryPick mergeMode arg contract", () => {
         "draft_commit_conflicts",
         "",
         "whitespace_tolerant",
+        "skip",
       );
       const cherryPickCall = getExecOutputMock.mock.calls.find(
         ([, args]) => Array.isArray(args) && args[0] === "cherry-pick",

--- a/src/test/helpers/config.ts
+++ b/src/test/helpers/config.ts
@@ -15,6 +15,7 @@ export function makeConfig(overrides?: Partial<Config>): Config {
     commits: {
       cherry_picking: "auto",
       cherry_picking_merge_mode: "default",
+      empty_commits: "skip",
       merge_commits: "fail",
     },
     copy_milestone: false,

--- a/src/test/helpers/mock-git.ts
+++ b/src/test/helpers/mock-git.ts
@@ -9,7 +9,7 @@ export function createMockGit(overrides?: Partial<GitApi>): GitApi {
     findMergeCommits: vi.fn().mockResolvedValue([]),
     push: vi.fn().mockResolvedValue(undefined),
     checkout: vi.fn().mockResolvedValue(undefined),
-    cherryPick: vi.fn().mockResolvedValue(null),
+    cherryPick: vi.fn().mockResolvedValue({ status: "picked" }),
     ...overrides,
   };
 }

--- a/src/test/helpers/test-repo.ts
+++ b/src/test/helpers/test-repo.ts
@@ -172,6 +172,33 @@ export async function addConflictingCommits(
 }
 
 /**
+ * Sets up a commit on main whose changes the target branch already contains,
+ * by cherry-picking it onto the target branch first. This is the state a
+ * repeat backport run finds after an earlier backport was merged.
+ * Returns the SHA of the commit on main (to use as the PR merge_commit_sha).
+ */
+export async function addAlreadyBackportedCommit(
+  dir: string,
+  targetBranch: string,
+  file: string,
+): Promise<string> {
+  const featureSha = await addCommit(
+    dir,
+    file,
+    `content from main for ${file}`,
+    `Change ${file} on main`,
+  );
+  await pushBranch(dir);
+
+  await gitCmd(`checkout ${targetBranch}`, dir);
+  await gitCmd(`cherry-pick -x ${featureSha}`, dir);
+  await gitCmd(`push origin ${targetBranch}`, dir);
+  await gitCmd("checkout main", dir);
+
+  return featureSha;
+}
+
+/**
  * Creates a pull request ref in the bare remote, simulating what GitHub does.
  * This allows `git fetch origin refs/pull/<number>/head` to succeed.
  */


### PR DESCRIPTION
`git cherry-pick` exits 1 both on a conflict and on a commit that comes out empty, and the action treats every exit 1 as a conflict. With `draft_commit_conflicts` the `git commit --all` after it fails too, with "nothing to commit", so the run aborts instead of drafting anything. #457

I tell the two apart by comparing the index against HEAD, which are equal only when the pick applied nothing. A pick that refuses to start exits 128, so on exit 1 the index holds nothing but the pick itself.

`empty_commits` is shaped like `merge_commits`. On `skip` the remaining commits are picked, and the target is reported as skipped when all of them were empty. On `fail` the run stays red, with a comment saying the branch already has the changes.

Two calls for you. The default is `skip`, so an unconfigured run that used to fail with a wrong conflict comment now ends skipped. `empty_commits: fail` restores the old outcome and flipping the default is one line. And skipped targets fall out of `was_successful_by_target`, same as the existing "PR already exists" skip. The thread asks for that distinction in the outputs, but it changes output semantics, so it is not here.

I left out the draft PR for the empty case. Nothing to resolve there, and it needs `git commit --allow-empty`, which gives a PR with no changed files.

Integration tests run against real git. I checked each of them fails without the fix. No `dist/`.
